### PR TITLE
First implementation of docker plugin with additional metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+language: go
+go:
+- 1.5.4
+- 1.6.2
+before_install:
+- go get github.com/tools/godep
+- if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+env:
+  global:
+    - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/kubesnap-plugin-collector-docker
+  matrix:
+    - TEST=unit
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $SNAP_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# snap collector plugin - Docker
+
+1. [Contributing Code](#contributing-code)
+2. [Contributing Examples](#contributing-examples)
+3. [Contribute Elsewhere](#contribute-elsewhere)
+4. [Thank You](#thank-you)
+
+This repository has dedicated developers from Intel working on updates. The most helpful way to contribute is by reporting your experience through issues. Issues may not be updated while we review internally, but they're still incredibly appreciated.
+
+## Contributing Code
+**_IMPORTANT_**: We encourage contributions to the project from the community. We ask that you keep the following guidelines in mind when planning your contribution.
+
+* Whether your contribution is for a bug fix or a feature request, **create an [Issue](https://github.com/intelsdi-x/snap-plugin-collector-docker/issues)** and let us know what you are thinking
+* **For bugs**, if you have already found a fix, feel free to submit a Pull Request referencing the Issue you created
+* **For feature requests**, we want to improve upon the library incrementally which means small changes at a time. In order ensure your PR can be reviewed in a timely manner, please keep PRs small, e.g. <10 files and <500 lines changed. If you think this is unrealistic, then mention that within the issue and we can discuss it
+
+Once you're ready to contribute code back to this repo, start with these steps:
+
+* Fork the appropriate sub-projects that are affected by your change
+* Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`  
+	```
+	$ git clone https://github.com/<yourGithubID>/<project>.git
+	```
+* Create a topic branch for your change and checkout that branch  
+    ```
+    $ git checkout -b some-topic-branch
+    ```
+* Make your changes and run the test suite if one is provided (see below)
+* Commit your changes and push them to your fork
+* Open a pull request for the appropriate project
+* Contributors will review your pull request, suggest changes, and merge it when it’s ready and/or offer feedback
+* To report a bug or issue, please open a new issue against this repository
+
+If you have questions feel free to contact the [maintainers](https://github.com/intelsdi-x/snap/blob/master/README.md#maintainers).
+
+## Contributing Examples
+The most immediately helpful way you can benefit this project is by cloning the repository, adding some further examples and submitting a pull request. 
+
+Have you written a blog post about how you use [snap](http://github.com/intelsdi-x/snap) and/or this plugin? Send it to us!
+
+## Contribute Elsewhere
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap
+
+## Thank You
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,82 @@
+{
+	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-docker",
+	"GoVersion": "go1.5",
+	"Deps": [
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.7.3",
+			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/mount",
+			"Comment": "v1.4.1-9203-g59231ea",
+			"Rev": "59231ea6d8bdff3d32140d7ab28aeb98fb93ebff"
+		},
+		{
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.1.0-21-g0bbddae",
+			"Rev": "0bbddae09c5a5419a8c6dcdd7ff90da3d450393b"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient",
+			"Rev": "412c004d923b7b89701e7a1632de83f843657a03"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/ns",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/str",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/core",
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
+			"Comment": "v0.13.0-beta-77-g5c1177e",
+			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+		},
+		{
+			"ImportPath": "github.com/oleiade/reflections",
+			"Comment": "0.1.2-2-g632977f",
+			"Rev": "632977f98cd34d217c4b57d0840ec188b3d3dcaf"
+		},
+		{
+			"ImportPath": "github.com/opencontainers/runc/libcontainer/cgroups",
+			"Comment": "v0.0.6-45-g4c767d7",
+			"Rev": "4c767d7046a79a7cf29b810742e5f7f2564f2d0c"
+		},
+		{
+			"ImportPath": "github.com/opencontainers/runc/libcontainer/configs",
+			"Comment": "v0.0.6-45-g4c767d7",
+			"Rev": "4c767d7046a79a7cf29b810742e5f7f2564f2d0c"
+		},
+		{
+			"ImportPath": "github.com/robfig/cron",
+			"Comment": "v1-7-g32d9c27",
+			"Rev": "32d9c273155a0506d27cf73dd1246e86a470997e"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "c1cd2254a6dd314c9d73c338c12688c9325d85c6"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Intel Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,270 @@
-# kubesnap-plugin-collector-docker
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+[![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-collector-docker.svg?branch=master)](https://travis-ci.com/intelsdi-x/snap-plugin-collector-docker)
+
+# snap collector plugin - Docker
+
+This plugin collects runtime metrics from Docker containers on the Docker host machine. It gathers information about resource usage and performance characteristics of running containers. 
+
+It's used in the [snap framework](http://github.com/intelsdi-x/snap).
+
+1. [Getting Started](#getting-started)
+  * [Installation](#installation)
+  * [Configuration and Usage](#configuration-and-usage)
+2. [Documentation](#documentation)
+  * [Collected Metrics](#collected-metrics)
+  * [Examples](#examples)
+  	* [Darwin](#darwin)
+  	* [Linux](#linux)
+3. [Community Support](#community-support)
+4. [Contributing](#contributing)
+5. [License](#license-and-authors)
+6. [Acknowledgements](#acknowledgements)
+
+## Getting Started
+
+In order to use this plugin you need Docker Engine installed. Visit [Install Docker Engine](https://docs.docker.com/engine/installation/) for detailed instructions how to do it.
+
+### Operating systems
+* Linux/amd64
+* Darwin/amd64 (Needs [docker-machine](https://docs.docker.com/v1.8/installation/mac/))
+
+### Installation
+
+You can get the pre-built binaries for your OS and architecture at snap's [GitHub Releases](https://github.com/intelsdi-x/snap/releases) page.
+
+#### To build the plugin binary:
+Fork https://github.com/intelsdi-x/snap-plugin-collector-docker  
+Clone repo into `$GOPATH/src/github.com/intelsdi-x/`:
+
+```
+$ git clone https://github.com/<yourGithubID>/snap-plugin-collector-docker.git
+```
+
+Build the plugin by running make within the cloned repo:
+```
+$ make
+```
+(It may take a while to pull dependencies if you don't have them already.)
+
+This builds the plugin in `/build/rootfs/`
+
+#### Run tests
+```
+$ ./scripts/test.sh unit
+```
+
+### Configuration and Usage
+* Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
+* Ensure `$SNAP_PATH` is exported  
+`export SNAP_PATH=$GOPATH/src/github.com/intelsdi-x/snap/build`
+
+## Documentation
+There are a number of other resources you can review to learn to use this plugin:
+* [Docker Documentation](https://docs.docker.com/)
+* [Docker Runtime Metrics](https://docs.docker.com/engine/articles/runmetrics/)
+* [snap Docker examples](#examples)
+* [snap docker_test.go](docker/docker_test.go)
+* [snap Docker JSON task example](examples/tasks/docker-file.json)
+
+### Collected Metrics
+All metrics gathered by this plugin are exposed by [cgroups](https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt).  
+
+This plugin has the ability to gather the following metrics:
+
+Namespace | Data Type | Description (optional)
+----------|-----------|-----------------------
+/intel/linux/docker/cpu_stats/cpu_usage/total_usage | uint64 | Total CPU time consumed
+/intel/linux/docker/cpu_stats/cpu_usage/usage_in_kernelmode | uint64 | CPU time consumed by tasks in system (kernel) mode
+/intel/linux/docker/cpu_stats/cpu_usage/usage_in_usermode | uint64 | CPU time consumed by tasks in user mode
+/intel/linux/docker/cpu_stats/cpu_usage/percpu_usage/\<N\> | uint64 | CPU time consumed on each N-th CPU by all tasks
+/intel/linux/docker/cpu_stats/throttling_data/periods | uint64 | number of period intervals that have elapsed
+/intel/linux/docker/cpu_stats/throttling_data/throttled_periods | uint64 | number of times tasks in a cgroup have been throttled
+/intel/linux/docker/cpu_stats/throttling_data/throttled_time | uint64 | total time duration for which tasks in a cgroup have been throttled
+/intel/linux/docker/memory_stats/cache | uint64 | page cache including tmpfs
+/intel/linux/docker/memory_stats/usage/usage | uint64 | reports the total current memory usage by processes in the cgroup
+/intel/linux/docker/memory_stats/usage/max_usage | uint64 | reports the maximum memory used by processes in the cgroup
+/intel/linux/docker/memory_stats/usage/failcnt | uint64 | reports the number of times that the memory limit has reached the value set in memory.limit_in_bytes
+/intel/linux/docker/memory_stats/swap_usage/usage | uint64 | reports the total swap space usage by processes in the cgroup
+/intel/linux/docker/memory_stats/swap_usage/max_usage | uint64 | reports the maximum swap space used by processes in the cgroup
+/intel/linux/docker/memory_stats/swap_usage/failcnt | uint64 | reports the number of times the swap space limit has reached the value set in memorysw.limit_in_bytes
+/intel/linux/docker/memory_stats/kernel_usage/usage | uint64 | reports the total kernel memory allocation by processes in the cgroup
+/intel/linux/docker/memory_stats/kernel_usage/max_usage | uint64 | reports the maximum kernel memory allocation by processes in the cgroup
+/intel/linux/docker/memory_stats/kernel_usage/failcnt | uint64 | reports the number of times the kernel memory allocation has reached the value set in kmem.limit_in_bytes
+/intel/linux/docker/memory_stats/stats/cache | uint64 | number of bytes of page cache memory
+/intel/linux/docker/memory_stats/stats/rss | uint64 | number of bytes of anonymous and swap cache memory
+/intel/linux/docker/memory_stats/stats/rss_huge | uint64 | number of bytes of anonymous transparent hugepages
+/intel/linux/docker/memory_stats/stats/mapped_file | uint64 | number of bytes of mapped file (includes tmpfs/shmem)
+/intel/linux/docker/memory_stats/stats/writeback | uint64 | number of bytes of file/anon cache that are queued for syncing to disk
+/intel/linux/docker/memory_stats/stats/pgpgin | uint64 | number of charging events to the memory cgroup
+/intel/linux/docker/memory_stats/stats/pgpgout | uint64 | number of uncharging events to the memory cgroup
+/intel/linux/docker/memory_stats/stats/pgfault | uint64 | number of page faults which happened since the creation of the cgroup
+/intel/linux/docker/memory_stats/stats/pgmajfault | uint64 | number of page major faults which happened since the creation of the cgroup
+/intel/linux/docker/memory_stats/stats/active_anon | uint64 | number of bytes of anonymous and swap cache memory on active LRU list
+/intel/linux/docker/memory_stats/stats/inactive_anon | uint64 | number of bytes of anonymous and swap cache memory on inactive LRU list
+/intel/linux/docker/memory_stats/stats/active_file | uint64 | number of bytes of file-backed memory on active LRU list
+/intel/linux/docker/memory_stats/stats/inactive_file | uint64 | number of bytes of file-backed memory on inactive LRU list
+/intel/linux/docker/memory_stats/stats/unevictable | uint64 | number of bytes of memory that cannot be reclaimed
+/intel/linux/docker/memory_stats/stats/hierarchical_memory_limit | uint64 | of bytes of memory limit with regard to hierarchy under which the memory cgroup is
+/intel/linux/docker/memory_stats/stats/total_\<counter\> | uint64 | hierarchical version of \<counter\>, which in addition to the cgroup's own value includes the sum of all hierarchical children's values of \<counter\>
+/intel/linux/docker/blkio_stats/io_service_bytes_recursive | uint64 | number of bytes transferred to/from the disk from all the descendant cgroups
+/intel/linux/docker/blkio_stats/io_service_recursive | uint64 | number of IOs (bio) issued to the disk from all the descendant cgroups
+/intel/linux/docker/blkio_stats/io_queue_recursive | uint64 | number of  requests queued up at any given instant from all the descendant cgroups
+/intel/linux/docker/blkio_stats/io_service_time_recursive | uint64 | amount of time between request dispatch and request completion from all the descendant cgroups
+/intel/linux/docker/blkio_stats/io_wait_time_recursive | uint64 | amount of time the IOs for this cgroup spent waiting in the scheduler queues for service from all the descendant cgroups
+/intel/linux/docker/blkio_stats/io_merged_recursive | uint64 | number of bios/requests merged into requests belonging to all the descendant cgroups
+/intel/linux/docker/blkio_stats/io_time_recursive | uint64 | disk time allocated to all devices from all the descendant cgroups
+/intel/linux/docker/blkio_stats/io_sectors_recursive | uint64 | number of sectors transferred to/from disk bys from all the descendant cgroups
+/intel/linux/docker/hugetlb_stats/\<hugepagesize\>/usage | uint64 | show current usage for "hugepagesize" hugetlb
+/intel/linux/docker/hugetlb_stats/\<hugepagesize\>/max_usage | uint64 | show max "hugepagesize" hugetlb usage recorded
+/intel/linux/docker/hugetlb_stats/\<hugepagesize\>/failcnt | uint64 | show the number of allocation failure due to HugeTLB limit
+
+### Examples
+#### Darwin
+
+Set docker-machine env.
+```
+$ eval "$(docker-machine env <dockerMachineName>)"
+```
+If this is your directory structure:
+```
+$GOPATH/src/github.com/intelsdi-x/snap/
+$GOPATH/src/github.com/intelsdi-x/snap-plugin-collector-docker/
+```
+
+In the `$GOPATH/src/github.com/intelsdi-x/` directory run the following:
+```
+$ snap-plugin-collector-docker/scripts/run_test_snap_plugin_collector_docker_darwin.sh 
+```
+
+This creates an image with your local directory of snap and snap-plugin-collector-docker in it using [`scripts/Dockerfile`](scripts/Dockerfile). From here you can run snap to gather container statistics. The [Dockerfile](http://docs.docker.com/engine/reference/builder/) assumes you have the snap-plugin-collector-docker repository locally. If you're using pre-built binaries, they need to be located somewhere in either `/snap` or `/snap-plugin-collector-docker`. 
+
+```
+$ docker images                                                                                   ✭
+REPOSITORY                                TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+intelsdi-x/snap-plugin-collector-docker   latest              44589b958838        14 hours ago        993.4 MB
+```
+After your image is created [`docker run`](https://docs.docker.com/engine/reference/run/) is used to create and enter a container with your image (this is included in the run script but the command will need to be run if you exit the container):
+```
+$ docker run -it -v /proc:/hostproc -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/run/docker.sock:/var/run/docker.sock -v ./static-docker:/usr/bin/docker <imageID/repositoryName> bash
+```
+
+```
+$ docker ps
+
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+6f98ccadbe76        7bf7678d93b1        "bash"              2 days ago          Up 4 hours                              adoring_colden
+```
+In another terminal run the following to enter your container again:
+```
+$ docker exec -it <containerID> bash
+```
+Now you have a terminal window to run snapd and one for snapctl and can continue into the Linux example. 
+
+#### Linux
+
+```
+$ docker ps
+
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+7720efd76bb8        ubuntu              "/bin/bash"         35 minutes ago      Up 35 minutes                           prickly_spence
+ad5221e8ae73        ubuntu              "/bin/bash"         36 minutes ago      Up 36 minutes                           suspicious_mirzakhani
+```
+
+In one terminal window in the /snap directory: Running snapd with auto discovery, log level 1, and trust disabled
+```
+$ $SNAP_PATH/bin/snapd -l 1 -t 0 -a ../snap-plugin-collector-docker/build/rootfs/:build/plugin/
+```
+Create task manifest for writing to a file. You can also use * (wildcard) as the container ID to list that metric for all containers. See [`examples/tasks/docker-file.json`](examples/tasks/docker-file.json):
+```json
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/total_usage":{},
+                "/intel/linux/docker/ad5221e8ae73/memory_stats/usage/usage": {},
+                "/intel/linux/docker/7720efd76bb8/memory_stats/usage/usage": {},
+                "/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/0/value": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": [
+                {
+                    "plugin_name": "passthru",                    
+                    "process": null,
+                    "publish": [
+                        {
+                            "plugin_name": "file",                            
+                            "config": {
+                                "file": "/tmp/snap-docker-file.log"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+```
+Another terminal window, also in /snap:
+```
+$ $SNAP_PATH/bin/snapctl task create -t docker-file.json
+```
+/tmp/snap-docker-file.log
+```
+2015-12-02 23:43:50.632800682 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats usage usage]|536576|hostname/7720efd76bb8
+2015-12-02 23:43:50.636374575 -0800 PST|[intel linux docker ad5221e8ae73 blkio_stats io_serviced_recursive 0 value]|220|hostname/ad5221e8ae73
+2015-12-02 23:43:50.639577224 -0800 PST|[intel linux docker ad5221e8ae73 memory_stats usage usage]|4304896|hostname/ad5221e8ae73
+2015-12-02 23:43:50.642809595 -0800 PST|[intel linux docker ad5221e8ae73 cpu_stats cpu_usage total_usage]|36801420|hostname/ad5221e8ae73
+2015-12-02 23:43:51.634380642 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats usage usage]|536576|hostname/7720efd76bb8
+2015-12-02 23:43:51.638242838 -0800 PST|[intel linux docker ad5221e8ae73 blkio_stats io_serviced_recursive 0 value]|220|hostname/ad5221e8ae73
+2015-12-02 23:43:51.644047525 -0800 PST|[intel linux docker ad5221e8ae73 memory_stats usage usage]|4304896|hostname/ad5221e8ae73
+2015-12-02 23:43:51.647942982 -0800 PST|[intel linux docker ad5221e8ae73 cpu_stats cpu_usage total_usage]|36801420|hostname/ad5221e8ae73
+2015-12-02 23:43:52.633682886 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats usage usage]|536576|hostname/7720efd76bb8
+```
+
+### Roadmap
+There isn't a current roadmap for this plugin, but it is in active development. As we launch this plugin, we do not have any outstanding requirements for the next release. If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-collector-docker/issues/new) and/or submit a [pull request](https://github.com/intelsdi-x/snap-plugin-collector-docker/pulls).
+
+## Community Support
+This repository is one of **many** plugins in the **snap framework**: a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap To reach out to other users, head to the [main framework](https://github.com/intelsdi-x/snap#community-support)
+
+## Contributing
+We love contributions!
+
+There's more than one way to give back, from examples to blogs to code updates. See our recommended process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+[snap](http://github.com/intelsdi-x/snap), along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
+
+## Acknowledgements
+
+* Author: [Marcin Krolik](https://github.com/marcin-krolik)
+
+**Thank you!** Your contribution is incredibly important to us.

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,113 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015-2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"errors"
+	"time"
+	"fmt"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+)
+
+const endpoint string = "unix:///var/run/docker.sock"
+
+
+type DockerClientInterface interface {
+	ListContainersAsMap() (map[string]docker.APIContainers, error)
+	GetContainerStats(string, time.Duration) (*docker.Stats, error)
+}
+
+type dockerClient struct{
+	cl *docker.Client
+}
+
+func NewDockerClient() (*dockerClient) {
+	client, err := docker.NewClient(endpoint)
+	if err != nil {
+		panic(err)
+	}
+	return &dockerClient{cl: client}
+}
+
+func (dc *dockerClient) FindCgroupMountpoint(subsystem string) (string, error) {
+	return cgroups.FindCgroupMountpoint(subsystem)
+}
+
+// getShortId returns short version of container ID (12 char)
+func GetShortId(dockerID string) (string, error) {
+	// get short version of container ID
+	if len(dockerID) < 12 {
+		return "", fmt.Errorf("Docker id %+s is too short (the length of id should equal at least 12)", dockerID)
+	}
+	return dockerID[:12], nil
+}
+
+func (dc *dockerClient) ListContainersAsMap() (map[string]docker.APIContainers, error) {
+
+	containers := make(map[string]docker.APIContainers)
+
+	containerList, err := dc.cl.ListContainers(docker.ListContainersOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cont := range containerList {
+		shortID, _ := GetShortId(cont.ID)
+		containers[shortID] = cont
+	}
+
+	if len(containers) == 0 {
+		return nil, errors.New("No docker conatiner found")
+	}
+
+	return containers, nil
+}
+
+func (dc *dockerClient) GetContainerStats(id string, timeout time.Duration) (*docker.Stats, error) {
+
+	var resultStats *docker.Stats
+
+	errChan := make(chan error, 1)
+	statsChan := make(chan *docker.Stats)
+	done := make(chan bool)
+
+	go func() {
+		errChan <- dc.cl.Stats(docker.StatsOptions{id, statsChan, true, done, timeout})
+		close(errChan)
+	}()
+	select {
+		case stats, ok  := <-statsChan:
+		resultStats = stats
+			if !ok {
+				statsChan = nil
+				break
+			}
+
+		case err := <-errChan:
+			return nil, err
+	}
+
+	return resultStats, nil
+}
+

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,0 +1,413 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015-2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"fmt"
+	"strings"
+	"github.com/intelsdi-x/snap/core"
+	"os"
+	"time"
+	"errors"
+	"github.com/intelsdi-x/snap-plugin-collector-docker/client"
+	"github.com/intelsdi-x/snap-plugin-utilities/ns"
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+
+	dock "github.com/fsouza/go-dockerclient"
+)
+
+const (
+	// namespace vendor prefix
+	NS_VENDOR = "intel"
+	// namespace plugin name
+	NS_PLUGIN = "docker"
+	// version of plugin
+	VERSION = 4
+)
+
+
+
+type containerData struct {
+	Id         string  	`json:"-"`
+	Status     string  	`json:"status"`
+	Created    int64   	`json:"creation_time"`
+	Image      string  	`json:"image_name"`
+	SizeRw     int64   	`json:"size_rw"`
+	SizeRootFs int64   	`json:"size_root_fs"`    // basic info about the container (status, uptime, etc.)
+	Stats      *dock.Stats 	`json:"stats"`		// container statistics (cpu usage, memory usage, network stats, etc.)
+}
+
+// docker collector plugin type
+type docker struct {
+	containers  	map[string]containerData 	// holds data for a container under its short id
+	initialized 	bool
+	client      	client.DockerClientInterface 	// client for communication with docker (basic info, stats, mount points)
+	list		map[string]dock.APIContainers	// contain list of all available docker containers with info about their specification
+
+
+}
+
+// Docker plugin initializer
+func New() *docker {
+	return &docker{
+		containers:  map[string]containerData{},
+		client: client.NewDockerClient(),
+		list: map[string]dock.APIContainers{},
+	}
+}
+
+
+// availableContainer returns IDs of all available docker containers
+func (d *docker) availableContainers() []string {
+	ids := []string{}
+
+	// iterate over list of available dockers
+	for id := range d.list {
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
+// validateDockerID returns true if docker with a given dockerID has been found on list of available dockers
+func (d *docker) validateDockerID(dockerID string) (bool) {
+
+	if _, exist := d.list[dockerID]; exist {
+		return true
+	}
+
+	return false
+}
+
+// validateMetricNamespace returns true if the given metric namespace has the required length
+func validateMetricNamespace(ns []string) (bool) {
+
+	if len(ns) < 4 {
+		// metric namespace has to contain the following 4 elements:
+		// "intel", "docker", "<docker_id>", "<metric_name>"
+		return false
+	}
+	return true
+}
+
+// getRequestedIDs returns requested docker ids
+func (d *docker) getRequestedIDs(mt ...plugin.MetricType) ([]string, error) {
+	rids := []string{}
+	for _, m := range mt {
+		ns := m.Namespace().Strings()
+		if ok := validateMetricNamespace(ns); !ok {
+			return nil, fmt.Errorf("Invalid name of metric %+s", m.Namespace().String())
+		}
+
+		rid := m.Namespace().Strings()[2]
+		if rid == "*" {
+			// all available dockers are requested
+			idsOfAllContainers := d.availableContainers()
+			if len(idsOfAllContainers) == 0 {
+				return nil, errors.New("No docker container found")
+			}
+			return idsOfAllContainers, nil
+		}
+		shortid, errId := client.GetShortId(rid)
+		if errId != nil {
+			return nil, errId
+		}
+
+		if !d.validateDockerID(shortid) {
+			return nil, fmt.Errorf("Docker container %+s cannot be found", rid)
+		}
+
+		rids = appendIfMissing(rids, shortid)
+	}
+
+	if len(rids) == 0 {
+		return nil, errors.New("Cannot retrieve requested docker id")
+	}
+	return rids, nil
+}
+
+func appendIfMissing(items []string, newItem string) []string {
+	for _, item := range items {
+		if newItem == item {
+			// do not append new item
+			return items
+		}
+	}
+	return append(items, newItem)
+}
+
+func (d *docker) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, error) {
+	metrics := []plugin.MetricType{}
+	var err error
+
+	// get list of all running containers
+	d.list, err = d.client.ListContainersAsMap()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "The list of running containers cannot be retrived, err=%+v", err)
+		return nil, err
+	}
+
+	// retrieve requested docker ids
+	rids, err := d.getRequestedIDs(mts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// for each requested id set adequate item into docker.container struct with stats
+	for _, rid := range rids {
+
+		if contSpec, exist := d.list[rid]; exist {
+			// set new item to docker.container structure
+			d.containers[rid] = containerData{
+				Id:         contSpec.ID,
+				Status:     contSpec.Status,
+				Created:    contSpec.Created,
+				Image:      contSpec.Image,
+				SizeRw:     contSpec.SizeRw,
+				SizeRootFs: contSpec.SizeRootFs,
+				Stats:      new(dock.Stats),
+			}
+
+		} else {
+			return nil, fmt.Errorf("Docker container does not exist, container_id=", rid)
+		}
+
+
+		stats, err := d.client.GetContainerStats(rid, 0)
+		if err != nil {
+			return nil, err
+		}
+		*d.containers[rid].Stats = *stats
+	}
+
+
+	for _, mt := range mts {
+
+		ids, err := d.getRequestedIDs(mt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, id := range ids {
+			metricName := mt.Namespace().Strings()[3:]
+			// Extract values by namespace from temporary struct and create metrics
+
+				metric := plugin.MetricType{
+					Timestamp_: time.Now(),
+					Namespace_: core.NewNamespace(NS_VENDOR, NS_PLUGIN, id).AddStaticElements(metricName...),
+					Data_:      ns.GetValueByNamespace(d.containers[id], metricName),
+					Tags_: 		mt.Tags(),
+					Config_: mt.Config(),
+				}
+				metrics = append(metrics, metric)
+		}
+
+	}
+
+	if len(metrics) == 0 {
+		return nil, errors.New("No metric found")
+	}
+
+	return metrics, nil
+}
+
+func (d *docker) GetMetricTypes(_ plugin.ConfigType) ([]plugin.MetricType, error) {
+	//var namespaces []string
+	var metricTypes []plugin.MetricType
+
+	//d.init()
+
+	// try to list all running containers to check docker client conn
+	if _, err := d.client.ListContainersAsMap(); err != nil {
+		fmt.Fprintln(os.Stderr, "The list of running containers cannot be retrived, err=%+v", err)
+		return nil, err
+	}
+
+	// Generate available namespace for data container structure
+
+	//prefix := strings.Join([]string{NS_VENDOR, NS_VENDOR, "*"}, "/")
+
+	availableMetrics := []string{}
+	// take names of available metrics based on tags for containerData type; do not add prefix (empty string)
+	ns.FromCompositionTags(containerData{Stats: new(dock.Stats)}, "", &availableMetrics)
+
+	fmt.Fprintln(os.Stderr, "Debug, len(namespaces1)=", len(availableMetrics))
+	for index, ns := range availableMetrics {
+		fmt.Fprintln(os.Stderr, "Debug, ns[", index, "]=",ns)
+	}
+
+	for _, metricName := range availableMetrics {
+
+		ns := core.NewNamespace(NS_VENDOR, NS_PLUGIN).
+			AddDynamicElement("docker_id", "the id of docker container").
+			AddStaticElements(strings.Split(metricName, "/")...)
+
+		metricType := plugin.MetricType{
+			Namespace_: ns,
+		}
+
+		metricTypes = append(metricTypes, metricType)
+	}
+
+	/*
+	//test, _ := d.client.ListContainersAsMap()
+	data := containerData{id:"aa", created: 1543}
+	ns.FromCompositionTags(data, prefix, &namespaces)
+	fmt.Fprintln(os.Stderr, "Debug, len(namespaces)=", len(namespaces))
+	for nr, ns := range namespaces {
+		fmt.Fprintln(os.Stderr, "Debug, iza ns[", nr, "]=", ns)
+	}
+*/
+	/*
+	// list of metrics
+	for _, statName := range availableStats {
+
+		ns := core.NewNamespace(NS_VENDOR, NS_PLUGIN).
+			AddDynamicElement("docker_id", "id of docker container").
+			AddStaticElements(statName...)
+
+		metricType := plugin.MetricType{
+			Namespace_: ns,
+		}
+
+		metricTypes = append(metricTypes, metricType)
+	}*/
+
+
+	return metricTypes, nil
+
+	/*
+
+
+		for _, cont := range containers {
+			//todo obsługa błedu
+			dockerShortID, _ := getShortId(cont.Id)
+
+			d.containers[dockerShortID] = containerData{
+				id: 		cont.Id,
+				status: 	cont.Status,
+				created: 	cont.Created,
+				image: 		cont.Image,
+				sizeRw: 	cont.SizeRw,
+				sizeRootFs: 	cont.SizeRootFs,
+				stats: 		new(dock.Stats),
+			}
+
+
+			fmt.Fprint(os.Stderr, " Debug, container id=", cont.Id)
+			fmt.Fprint(os.Stderr, " Debug, container data=", d.containers[cont.Id])
+		}
+
+		//todo do przerzucenia później
+
+
+		cl, err := dock.NewClient(endpoint)
+		if err != nil {
+			fmt.Println("[ERROR] Could not create docker client!")
+			return nil, err
+		}
+
+		errChan := make(chan error, 1)
+		statsChan := make(chan *dock.Stats)
+		done := make(chan bool)
+
+		id := containers[0].Id
+		go func() {
+			//todo container id tymczasowo
+			errChan <- cl.Stats(dock.StatsOptions{id, statsChan, true, done, 0})
+			close(errChan)
+		}()
+
+		for {
+			stats, ok := <-statsChan
+
+			if !ok {
+				break
+			}
+
+			//set stats
+
+			fmt.Fprintf(os.Stderr, "Debug, izaPRZED zebrane statystyki memory: %+s", stats.MemoryStats)
+			fmt.Fprintf(os.Stderr, "/n/n")
+			fmt.Fprintf(os.Stderr, "Debug, izaPRZED zebrane statystyki cpu: %+s", stats.CPUStats)
+
+			*d.containers[id].stats = *stats
+			fmt.Fprintf(os.Stderr, "stats=", stats)
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintf(os.Stderr, "Debug, iza zebrane statystyki memory: %+s", d.containers[id].stats.MemoryStats)
+			fmt.Fprintf(os.Stderr, "/n/n")
+			fmt.Fprintf(os.Stderr, "Debug, iza zebrane statystyki cpu: %+s", d.containers[id].stats.CPUStats)
+			//todo iza tymczasowo
+			//resultStats = append(resultStats, stats)
+		}
+		err = <-errChan
+		if err != nil {
+			return nil, err
+		}
+
+	*/
+
+	/*		//todo czy to jest potyrzebne
+	// list all running containers
+	_, err := dockerClient.ListContainers()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range d.containersInfo {
+		// calling getStats will populate stats object
+		// parsing it one will get info on available namespace
+		d.getStats(container.Id)
+
+		// marshal-unmarshal to get map with json tags as keys
+		jsondata, _ := json.Marshal(d.stats)
+		var jmap map[string]interface{}
+		json.Unmarshal(jsondata, &jmap)
+
+		// parse map to get namespace strings
+		d.tools.Map2Namespace(jmap, container.Id[:12], &namespaces)
+	}
+
+	// wildcard for container ID
+	if len(d.containersInfo) > 0 {
+		jsondata, _ := json.Marshal(d.stats)
+		var jmap map[string]interface{}
+		json.Unmarshal(jsondata, &jmap)
+		d.tools.Map2Namespace(jmap, "*", &namespaces)
+	}
+
+	for _, namespace := range namespaces {
+		// construct full namespace
+		fullNs := filepath.Join(NS_VENDOR, NS_PLUGIN, namespace)
+		metricTypes = append(metricTypes, plugin.MetricType{Namespace_: core.NewNamespace(strings.Split(fullNs, "/")...)})
+	}
+	*/
+
+	return metricTypes, nil
+}
+
+func (d *docker) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	return cpolicy.New(), nil
+}

--- a/examples/tasks/docker-file.json
+++ b/examples/tasks/docker-file.json
@@ -1,0 +1,24 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/docker/*":{}
+            },
+            "config": {},
+	    "process": null,
+            "publish": [
+                {
+                    "plugin_name": "file",                    
+                    "config": {
+                        "file": "/tmp/snap-docker-file.log"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,44 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/intelsdi-x/snap-plugin-collector-docker/docker"
+	"github.com/intelsdi-x/snap/control/plugin"
+)
+
+func main() {
+
+	plugin.Start(
+		plugin.NewPluginMeta(
+			docker.NS_PLUGIN,
+			docker.VERSION,
+			plugin.CollectorPluginType,
+			[]string{},
+			[]string{plugin.SnapGOBContentType},
+			plugin.ConcurrencyCount(1)),
+			docker.New(),
+			os.Args[1],
+	)
+}

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:latest  
+ENV GOPATH=$GOPATH:/app
+ENV SNAP_PATH=/go/src/github.com/intelsdi-x/snap/build
+RUN apt-get update && \
+    apt-get -y install facter && \
+    apt-get -y install vim
+RUN go get github.com/tools/godep && \
+    go get golang.org/x/tools/cmd/goimports && \
+    go get golang.org/x/tools/cmd/cover && \
+    go get github.com/smartystreets/goconvey
+WORKDIR /go/src/github.com/intelsdi-x/
+RUN git clone https://github.com/intelsdi-x/gomit.git
+WORKDIR /go/src/github.com/intelsdi-x/snap-plugin-collector-docker
+ADD ./snap-plugin-collector-docker /go/src/github.com/intelsdi-x/snap-plugin-collector-docker
+RUN make
+WORKDIR /go/src/github.com/intelsdi-x/snap
+ADD ./snap /go/src/github.com/intelsdi-x/snap
+RUN scripts/deps.sh
+RUN make

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "snap-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Snap Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Snap Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/run_test_snap_plugin_collector_docker_darwin.sh
+++ b/scripts/run_test_snap_plugin_collector_docker_darwin.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+#http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#
+#Copyright 2015 Intel Corporation
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+docker build -t intelsdi-x/snap-plugin-collector-docker -f snap-plugin-collector-docker/scripts/Dockerfile .
+docker run -it -v /proc:/hostproc -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/run/docker.sock:/var/run/docker.sock -v ./static-docker:/usr/bin/docker intelsdi-x/snap-plugin-collector-docker bash

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get golang.org/x/tools/cmd/cover
+	go get github.com/fsouza/go-dockerclient
+        go get github.com/stretchr/testify/mock
+	
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go ./docker ./client"
+	VET_DIRS=". ./docker/... ./client/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+ 
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+ 
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+ 
+	go tool cover -func profile.cov
+ 
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+fi


### PR DESCRIPTION
Added collecting docker network stats + specification info - raw stats value are exposed

Currently docker collector plugin exposes the following metrics:

```
NAMESPACE                                                                
/intel/docker/*/creation_time                                          
/intel/docker/*/image_name                                              
/intel/docker/*/size_root_fs                                             
/intel/docker/*/size_rw                                                  
/intel/docker/*/stats/cpu_stats/cpu_usage/total_usage                    
/intel/docker/*/stats/cpu_stats/cpu_usage/usage_in_kernelmode            
/intel/docker/*/stats/cpu_stats/cpu_usage/usage_in_usermode              
/intel/docker/*/stats/cpu_stats/system_cpu_usage                         
/intel/docker/*/stats/cpu_stats/throttling_data/periods                  
/intel/docker/*/stats/cpu_stats/throttling_data/throttled_periods        
/intel/docker/*/stats/cpu_stats/throttling_data/throttled_time           
/intel/docker/*/stats/memory_stats/failcnt                               
/intel/docker/*/stats/memory_stats/limit                                 
/intel/docker/*/stats/memory_stats/max_usage                             
/intel/docker/*/stats/memory_stats/stats/active_anon                     
/intel/docker/*/stats/memory_stats/stats/active_file                     
/intel/docker/*/stats/memory_stats/stats/cache                           
/intel/docker/*/stats/memory_stats/stats/hierarchical_memory_limit       
/intel/docker/*/stats/memory_stats/stats/inactive_anon                   
/intel/docker/*/stats/memory_stats/stats/inactive_file                   
/intel/docker/*/stats/memory_stats/stats/mapped_file                     
/intel/docker/*/stats/memory_stats/stats/pgfault                         
/intel/docker/*/stats/memory_stats/stats/pgmajfault                     
/intel/docker/*/stats/memory_stats/stats/pgpgin                         
/intel/docker/*/stats/memory_stats/stats/pgpgout                         
/intel/docker/*/stats/memory_stats/stats/rss                             
/intel/docker/*/stats/memory_stats/stats/rss_huge                        
/intel/docker/*/stats/memory_stats/stats/total_active_anon               
/intel/docker/*/stats/memory_stats/stats/total_active_file              
/intel/docker/*/stats/memory_stats/stats/total_cache                     
/intel/docker/*/stats/memory_stats/stats/total_inactive_anon             
/intel/docker/*/stats/memory_stats/stats/total_inactive_file             
/intel/docker/*/stats/memory_stats/stats/total_mapped_file               
/intel/docker/*/stats/memory_stats/stats/total_pgfault                  
/intel/docker/*/stats/memory_stats/stats/total_pgmafault                 
/intel/docker/*/stats/memory_stats/stats/total_pgpgin                    
/intel/docker/*/stats/memory_stats/stats/total_pgpgout                   
/intel/docker/*/stats/memory_stats/stats/total_rss                       
/intel/docker/*/stats/memory_stats/stats/total_rss_huge                  
/intel/docker/*/stats/memory_stats/stats/total_unevictable               
/intel/docker/*/stats/memory_stats/stats/total_writeback                 
/intel/docker/*/stats/memory_stats/stats/unevictable                     
/intel/docker/*/stats/memory_stats/stats/writeback                       
/intel/docker/*/stats/memory_stats/usage                                 
/intel/docker/*/stats/network/rx_bytes                                   
/intel/docker/*/stats/network/rx_dropped                                 
/intel/docker/*/stats/network/rx_errors                                  
/intel/docker/*/stats/network/rx_packets                                 
/intel/docker/*/stats/network/tx_bytes                                   
/intel/docker/*/stats/network/tx_dropped                                 
/intel/docker/*/stats/network/tx_errors                                  
/intel/docker/*/stats/network/tx_packets                                 
/intel/docker/*/stats/precpu_stats/cpu_usage/total_usage                 
/intel/docker/*/stats/precpu_stats/cpu_usage/usage_in_kernelmode         
/intel/docker/*/stats/precpu_stats/cpu_usage/usage_in_usermode           
/intel/docker/*/stats/precpu_stats/system_cpu_usage                      
/intel/docker/*/stats/precpu_stats/throttling_data/periods               
/intel/docker/*/stats/precpu_stats/throttling_data/throttled_periods     
/intel/docker/*/stats/precpu_stats/throttling_data/throttled_time           
/intel/docker/*/status                                                                                   

```

WIP
- [x] Add docker network stats as a raw stats value
- [x] Add docker specification info as exposed metrics
- [ ] Change format of docker/creation_time value
- [ ] Add metric memory/working_set (the memory being used and not easily dropped by the kernel)
- [ ] Update information about metrics in READMEs
