### PR TITLE
Expose first network interface stats

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -361,26 +361,20 @@ func isFullLengthID(dockerID string) bool {
 	return false
 }
 
-func networkStatsFromProc(rootFs string, pid int) (map[string]wrapper.NetworkInterface, error) {
+func networkStatsFromProc(rootFs string, pid int) (ifaceStats []wrapper.NetworkInterface, errout error) {
 
-	netStats := map[string]wrapper.NetworkInterface{}
 	netStatsFile := filepath.Join(rootFs, "proc", strconv.Itoa(pid), "/net/dev")
-
-	ifaceStats, err := scanInterfaceStats(netStatsFile)
+	var err error
+	ifaceStats, err = scanInterfaceStats(netStatsFile)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read network stats: %v", err)
 	}
 
-	// return network stats as a map, where name of interface is a key
-	for _, ifaceStat := range ifaceStats {
-		netStats[ifaceStat.Name] = ifaceStat
-	}
-
-	if len(netStats) == 0 {
+	if len(ifaceStats) == 0 {
 		return nil, errors.New("No network interface found")
 	}
 
-	return netStats, nil
+	return ifaceStats, nil
 }
 
 func isIgnoredDevice(ifName string) bool {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 
 func main() {
 
+	dockerInst := docker.New()
 	plugin.Start(
 		plugin.NewPluginMeta(
 			docker.NS_PLUGIN,
@@ -38,7 +39,7 @@ func main() {
 			[]string{},
 			[]string{plugin.SnapGOBContentType},
 			plugin.ConcurrencyCount(1)),
-			docker.New(),
+			dockerInst,
 			os.Args[1],
 	)
 }

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -49,15 +49,15 @@ type Stats interface {
 }
 
 type Statistics struct {
-	Network     map[string]NetworkInterface `json:"network"`
-	Connection  TcpInterface                `json:"connection"` //TCP, TCP6 connection stats
-	CgroupStats *cgroups.Stats              `json:"cgroups"`
-	Labels map[string]string `json:"labels"`
+	Network     []NetworkInterface `json:"network"`
+	Connection  TcpInterface       `json:"connection"` //TCP, TCP6 connection stats
+	CgroupStats *cgroups.Stats     `json:"cgroups"`
+	Labels      map[string]string  `json:"labels"`
 }
 
 type NetworkInterface struct {
 	// Name is the name of the network interface.
-	Name string `json:"-"`
+	Name string `json:"name"`
 
 	RxBytes   uint64 `json:"rx_bytes"`
 	RxPackets uint64 `json:"rx_packets"`
@@ -71,7 +71,7 @@ type NetworkInterface struct {
 
 func NewStatistics() *Statistics {
 	return &Statistics{
-		Network:     map[string]NetworkInterface{},
+		Network:     []NetworkInterface{},
 		CgroupStats: cgroups.NewStats(),
 		Connection: TcpInterface{
 			Tcp:  TcpStat{},


### PR DESCRIPTION
- take the first network interface stats and expose them one level higher in hierarchy (ie.:.../docker/network/rx_bytes)
