### PR TITLE
Added filesystem metrics

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,41 +22,28 @@ limitations under the License.
 package client
 
 import (
-	"errors"
-	//"time"
 	"bufio"
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	//"syscall"
-	"io/ioutil"
 
 	"github.com/fsouza/go-dockerclient"
-	"github.com/opencontainers/runc/libcontainer/cgroups"
-	"os"
-
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/common"
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/fs"
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/network"
 	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/wrapper"
 	"github.com/intelsdi-x/snap-plugin-utilities/ns"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 const endpoint string = "unix:///var/run/docker.sock"
 
-type storageDriver string
-
 const (
-	devicemapperStorageDriver storageDriver = "devicemapper"
-	aufsStorageDriver         storageDriver = "aufs"
-	overlayStorageDriver      storageDriver = "overlay"
-	zfsStorageDriver          storageDriver = "zfs"
-)
-
-const (
-	// The read write layers exist here.
-	aufsRWLayer = "diff"
-	// Path to the directory where docker stores log files if the json logging driver is enabled.
-	pathToContainersDir = "containers"
-	memLimitInBytesCounter = "memory.limit_in_bytes"
+	memLimitInBytesCounter     = "memory.limit_in_bytes"
 	memSwapLimitInBytesCounter = "memory.memsw.limit_in_bytes"
 
 	// output stats key for limit in bytes
@@ -67,16 +54,19 @@ const (
 
 type DockerClientInterface interface {
 	ListContainersAsMap() (map[string]docker.APIContainers, error)
-	//GetContainerStats(string, time.Duration) (*docker.Stats, error)
 	GetStatsFromContainer(string) (*wrapper.Statistics, error)
 	InspectContainer(string) (*docker.Container, error)
 	FindCgroupMountpoint(string) (string, error)
 }
 
-var networkMetrics []string = []string {}
-
 type dockerClient struct {
 	cl *docker.Client
+}
+
+type deviceInfo struct {
+	device string
+	major  string
+	minor  string
 }
 
 func NewDockerClient() *dockerClient {
@@ -84,8 +74,7 @@ func NewDockerClient() *dockerClient {
 	if err != nil {
 		panic(err)
 	}
-	sample := wrapper.NetworkInterface{}
-	ns.FromCompositionTags(sample, "", &networkMetrics)
+
 	return &dockerClient{cl: client}
 }
 
@@ -119,35 +108,6 @@ func (dc *dockerClient) ListContainersAsMap() (map[string]docker.APIContainers, 
 	return containers, nil
 }
 
-/*
-func (dc *dockerClient) GetContainerStats(id string, timeout time.Duration) (*docker.Stats, error) {
-
-	var resultStats *docker.Stats
-
-	errChan := make(chan error, 1)
-	statsChan := make(chan *docker.Stats)
-	done := make(chan bool)
-
-	go func() {
-		errChan <- dc.cl.Stats(docker.StatsOptions{id, statsChan, true, done, timeout})
-		close(errChan)
-	}()
-	select {
-		case stats, ok  := <-statsChan:
-		resultStats = stats
-			if !ok {
-				statsChan = nil
-				break
-			}
-
-		case err := <-errChan:
-			return nil, err
-	}
-
-	return resultStats, nil
-}
-*/
-
 // isRunningSystemd returns true if the host was booted with systemd
 //func isRunningSystemd() bool {
 //	// todo
@@ -163,38 +123,32 @@ func (dc *dockerClient) GetContainerStats(id string, timeout time.Duration) (*do
 //}
 
 func GetSubsystemPath(subsystem string, id string) (string, error) {
-	var groupPath string
-	mountpoint, err := cgroups.FindCgroupMountpoint(subsystem)
+	groupPath, err := cgroups.FindCgroupMountpoint(subsystem)
 	if err != nil {
 		fmt.Printf("[WARNING] Could not find mount point for %s\n", subsystem)
 		return "", err
 	}
-	if id == "/" {
-		groupPath = mountpoint
-	//} else if isRunningSystemd() {
-	//	fmt.Fprintln(os.Stderr, "Debug: create path to cgroup for given docker id base on systemd")
-	//	slice := "system.slice"
-	//	// create path to cgroup for given docker id
-	//	groupPath = filepath.Join(mountpoint, slice, "docker-"+id+".scope")
-	} else {
+	if id != "/" {
 		// create path to cgroup for given docker id
-		//groupPath = filepath.Join(mountpoint, "docker", id)
-		groupPath = filepath.Join(mountpoint, id)
+		groupPath = filepath.Join(groupPath, id)
 	}
+
 	return groupPath, nil
 }
 
 // GetStatsFromContainer returns docker containers stats: cgroups stats (cpu usage, memory usage, etc.) and network stats (tx_bytes, rx_bytes etc.)
 // Notes: incoming container id has to be full-length to be able to inspect container
 func (dc *dockerClient) GetStatsFromContainer(id string) (*wrapper.Statistics, error) {
+
 	var (
-		stats = wrapper.NewStatistics()
-		groupWrap = wrapper.Cgroups2Stats // wrapper for cgroup name and interface for stats extraction
-		err error
-		workingSet uint64
+		stats        = wrapper.NewStatistics()
+		groupWrap    = wrapper.Cgroups2Stats // wrapper for cgroup name and interface for stats extraction
+		err          error
+		workingSet   uint64
 		wrapperPaths map[string]string
 	)
-	var container *docker.Container
+	container := &docker.Container{}
+
 	var pid int
 	if id != "/" {
 		if !isFullLengthID(id) {
@@ -211,8 +165,9 @@ func (dc *dockerClient) GetStatsFromContainer(id string) (*wrapper.Statistics, e
 		pid = container.State.Pid
 		// fill cgroup paths for wrapper elements according to parsed cgroup file
 		wrapperPaths, _ = parseProcCgroupFile(pid)
+
 	} else {
-		wrapperPaths = map[string]string {}
+		wrapperPaths = map[string]string{}
 		for cg, _ := range groupWrap {
 			if _, err := GetSubsystemPath(cg, "/"); err != nil {
 				continue
@@ -221,8 +176,8 @@ func (dc *dockerClient) GetStatsFromContainer(id string) (*wrapper.Statistics, e
 			}
 		}
 	}
+
 	////FIXME:REMOVEIT\/
-	//fmt.Fprintf(os.Stderr, "cgroups for %s: %+v\n", id, wrapperPaths)
 	for cg, stat := range groupWrap {
 		var err error
 		var groupPath string
@@ -263,30 +218,18 @@ func (dc *dockerClient) GetStatsFromContainer(id string) (*wrapper.Statistics, e
 	// gather memory limit
 	if cgPath, gotMem := wrapperPaths["memory"]; gotMem {
 		groupPath, _ := GetSubsystemPath("memory", cgPath)
-		memLimit, _ := ReadUintFromFile(filepath.Join(groupPath, memLimitInBytesCounter), 64)
-		memSwLimit, _ := ReadUintFromFile(filepath.Join(groupPath, memSwapLimitInBytesCounter), 64)
+		memLimit, _ := common.ReadUintFromFile(filepath.Join(groupPath, memLimitInBytesCounter), 64)
+		memSwLimit, _ := common.ReadUintFromFile(filepath.Join(groupPath, memSwapLimitInBytesCounter), 64)
 		stats.CgroupStats.MemoryStats.Stats[memLimitInBytesKey] = memLimit
 		stats.CgroupStats.MemoryStats.Stats[memSwapLimitInBytesKey] = memSwLimit
 	}
 
 	if id != "/" {
-		//if !isFullLengthID(id) {
-		//	return stats, fmt.Errorf("Container id %+v is not fully-length - cannot inspect container", id)
-		//}
-		//// inspect container based only on fully-length container id.
-		////container, err := dc.InspectContainer(id)
-		//
-		//if err != nil {
-		//	fmt.Fprintf(os.Stderr, "Unable to get inspect container to get pid, err=%v", err)
-		//	// only log error message and return stats (contains cgroups stats)
-		//	return stats, nil
-		//}
-
 		rootFs := "/"
 
-		stats.Network, err = networkStatsFromProc(rootFs, pid)
+		stats.Network, err = network.NetworkStatsFromProc(rootFs, pid)
 		extractContainerLabels := func(container *docker.Container) map[string]string {
-			res := map[string]string {}
+			res := map[string]string{}
 			config := container.Config
 			if config == nil {
 				return res
@@ -303,96 +246,28 @@ func (dc *dockerClient) GetStatsFromContainer(id string) (*wrapper.Statistics, e
 			fmt.Fprintf(os.Stderr, "Unable to get network stats, containerID=%+v, pid %d: %v", container.ID, pid, err)
 		}
 
-		stats.Connection.Tcp, err = tcpStatsFromProc(rootFs, pid, "net/tcp")
+		stats.Connection.Tcp, err = network.TcpStatsFromProc(rootFs, pid)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to get tcp stats from pid %d: %v", pid, err)
 		}
 
-		stats.Connection.Tcp6, err = tcpStatsFromProc(rootFs, pid, "net/tcp6")
+		stats.Connection.Tcp6, err = network.Tcp6StatsFromProc(rootFs, pid)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to get tcp6 stats from pid %d: %v", pid, err)
 		}
+
 	} else {
-		stats.Network, err = networkStatsFromRoot()
+		stats.Network, err = network.NetworkStatsFromRoot()
 		if err != nil {
 			// only log error message
 			fmt.Fprintf(os.Stderr, "Unable to get network stats, containerID=%v, %v", id, err)
 		}
+
 	}
 
-	return stats, nil
-}
-
-func tcpStatsFromProc(rootFs string, pid int, file string) (wrapper.TcpStat, error) {
-	tcpStatsFile := filepath.Join(rootFs, "proc", strconv.Itoa(pid), file)
-
-	tcpStats, err := scanTcpStats(tcpStatsFile)
+	stats.Filesystem, err = fs.GetFsStats(container)
 	if err != nil {
-		return tcpStats, fmt.Errorf("Cannot obtain tcp stats: %v", err)
-	}
-
-	return tcpStats, nil
-}
-
-func scanTcpStats(tcpStatsFile string) (wrapper.TcpStat, error) {
-
-	var stats wrapper.TcpStat
-
-	data, err := ioutil.ReadFile(tcpStatsFile)
-	if err != nil {
-		return stats, fmt.Errorf("Cannot open %s: %v", tcpStatsFile, err)
-	}
-
-	tcpStateMap := map[string]uint64{
-		"01": 0, //ESTABLISHED
-		"02": 0, //SYN_SENT
-		"03": 0, //SYN_RECV
-		"04": 0, //FIN_WAIT1
-		"05": 0, //FIN_WAIT2
-		"06": 0, //TIME_WAIT
-		"07": 0, //CLOSE
-		"08": 0, //CLOSE_WAIT
-		"09": 0, //LAST_ACK
-		"0A": 0, //LISTEN
-		"0B": 0, //CLOSING
-	}
-
-	reader := strings.NewReader(string(data))
-	scanner := bufio.NewScanner(reader)
-
-	scanner.Split(bufio.ScanLines)
-
-	// Discard header line
-	if b := scanner.Scan(); !b {
-		return stats, scanner.Err()
-	}
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		state := strings.Fields(line)
-		// TCP state is the 4th field.
-		// Format: sl local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt  uid timeout inode
-		tcpState := state[3]
-		_, ok := tcpStateMap[tcpState]
-		if !ok {
-			return stats, fmt.Errorf("invalid TCP stats line: %v", line)
-		}
-		tcpStateMap[tcpState]++
-	}
-
-	stats = wrapper.TcpStat{
-		Established: tcpStateMap["01"],
-		SynSent:     tcpStateMap["02"],
-		SynRecv:     tcpStateMap["03"],
-		FinWait1:    tcpStateMap["04"],
-		FinWait2:    tcpStateMap["05"],
-		TimeWait:    tcpStateMap["06"],
-		Close:       tcpStateMap["07"],
-		CloseWait:   tcpStateMap["08"],
-		LastAck:     tcpStateMap["09"],
-		Listen:      tcpStateMap["0A"],
-		Closing:     tcpStateMap["0B"],
+		fmt.Fprintf(os.Stderr, "Unable to get filesystem stats for docker: %v, err=", id, err)
 	}
 
 	return stats, nil
@@ -415,192 +290,10 @@ func isFullLengthID(dockerID string) bool {
 	return false
 }
 
-func networkStatsFromProc(rootFs string, pid int) (ifaceStats []wrapper.NetworkInterface, errout error) {
-
-	netStatsFile := filepath.Join(rootFs, "proc", strconv.Itoa(pid), "/net/dev")
-	var err error
-	ifaceStats, err = scanInterfaceStats(netStatsFile)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read network stats: %v", err)
-	}
-
-	if len(ifaceStats) == 0 {
-		return nil, errors.New("No network interface found")
-	}
-
-	return ifaceStats, nil
-}
-
-const networkInterfacesDir = "/sys/class/net"
-
-func listRootNetworkDevices() (devNames []string, _ error) {
-	entries, err := ioutil.ReadDir(networkInterfacesDir)
-	if err != nil {
-		return nil, err
-	}
-	devNames = []string {}
-	for _, e := range entries {
-		if e.Mode() & os.ModeSymlink == os.ModeSymlink {
-			e, err = os.Stat(filepath.Join(networkInterfacesDir, e.Name()))
-			if err != nil || !e.IsDir() {
-				continue
-			}
-			devNames = append(devNames, e.Name())
-		} else if e.IsDir() {
-			devNames = append(devNames, e.Name())
-		}
-	}
-	return devNames, nil
-}
-
-func networkStatsFromRoot() (ifaceStats []wrapper.NetworkInterface, _ error) {
-	devNames, err := listRootNetworkDevices()
-	if err != nil {
-		return nil, err
-	}
-	ifaceStats = []wrapper.NetworkInterface {}
-	for _, name := range(devNames) {
-		if isIgnoredDevice(name) {
-			continue
-		}
-		if stats, err := interfaceStatsFromDir(name); err != nil {
-			return nil, err
-		} else {
-			ifaceStats = append(ifaceStats, *stats)
-		}
-	}
-	return ifaceStats, nil
-}
-
-func ReadUintFromFile(path string, bits int) (uint64, error) {
-	if valb, err := ioutil.ReadFile(path); err != nil {
-		return 0, err
-	} else {
-		var val uint64
-		val, err = strconv.ParseUint(strings.TrimSpace(string(valb)), 10, bits)
-		return val, err
-	}
-}
-
-func interfaceStatsFromDir(ifaceName string) (*wrapper.NetworkInterface, error) {
-	stats := wrapper.NetworkInterface{Name: ifaceName}
-	statsValues := map[string]uint64 {}
-	for _, metric := range networkMetrics {
-		if metric == "name" {
-			continue
-		}
-		val, err := ReadUintFromFile(filepath.Join(networkInterfacesDir, ifaceName, "statistics", metric), 64)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't read interface statistics %s/%s: %v", ifaceName, metric, err)
-		}
-		statsValues[metric] = val
-	}
-	SetIfaceStatsFromMap(&stats, statsValues)
-	return &stats, nil
-}
-
-func SetIfaceStatsFromMap(stats *wrapper.NetworkInterface, values map[string]uint64) {
-	stats.RxBytes = values["rx_bytes"]
-	stats.RxErrors = values["rx_errors"]
-	stats.RxPackets = values["rx_packets"]
-	stats.RxDropped = values["rx_dropped"]
-	stats.TxBytes = values["tx_bytes"]
-	stats.TxErrors = values["tx_errors"]
-	stats.TxPackets = values["tx_packets"]
-	stats.TxDropped = values["tx_dropped"]
-}
-
-func SetMapFromIfaceStats(values map[string]uint64, stats *wrapper.NetworkInterface) {
-	values["rx_bytes"] = stats.RxBytes
-	values["rx_errors"] = stats.RxErrors
-	values["rx_packets"] = stats.RxPackets
-	values["rx_dropped"] = stats.RxDropped
-	values["tx_bytes"] = stats.TxBytes
-	values["tx_errors"] = stats.TxErrors
-	values["tx_packets"] = stats.TxPackets
-	values["tx_dropped"] = stats.TxDropped
-}
-
-func isIgnoredDevice(ifName string) bool {
-	ignoredDevicePrefixes := []string{"lo", "veth", "docker"}
-	for _, prefix := range ignoredDevicePrefixes {
-		if strings.HasPrefix(strings.ToLower(ifName), prefix) {
-			return true
-		}
-	}
-	return false
-}
-
-func scanInterfaceStats(netStatsFile string) ([]wrapper.NetworkInterface, error) {
-	file, err := os.Open(netStatsFile)
-	if err != nil {
-		return nil, fmt.Errorf("failure opening %s: %v", netStatsFile, err)
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-
-	// Discard header lines
-	for i := 0; i < 2; i++ {
-		if b := scanner.Scan(); !b {
-			return nil, scanner.Err()
-		}
-	}
-
-	stats := []wrapper.NetworkInterface{}
-	for scanner.Scan() {
-		line := scanner.Text()
-		line = strings.Replace(line, ":", "", -1)
-
-		fields := strings.Fields(line)
-		// If the format of the  line is invalid then don't trust any of the stats
-		// in this file.
-		if len(fields) != 17 {
-			return nil, fmt.Errorf("invalid interface stats line: %v", line)
-		}
-
-		devName := fields[0]
-
-		if isIgnoredDevice(devName) {
-			continue
-		}
-
-		i := wrapper.NetworkInterface{
-			Name: devName,
-		}
-
-		statFields := append(fields[1:5], fields[9:13]...)
-		statPointers := []*uint64{
-			&i.RxBytes, &i.RxPackets, &i.RxErrors, &i.RxDropped,
-			&i.TxBytes, &i.TxPackets, &i.TxErrors, &i.TxDropped,
-		}
-
-		err := setInterfaceStatValues(statFields, statPointers)
-		if err != nil {
-			return nil, fmt.Errorf("cannot parse interface stats (%v): %v", err, line)
-		}
-
-		stats = append(stats, i)
-	}
-
-	return stats, nil
-}
-
-func setInterfaceStatValues(fields []string, pointers []*uint64) error {
-	for i, v := range fields {
-		val, err := strconv.ParseUint(v, 10, 64)
-		if err != nil {
-			return err
-		}
-		*pointers[i] = val
-	}
-	return nil
-}
-
 func parseProcCgroupFile(pid int) (map[string]string, error) {
 	cgroupPath := filepath.Join("/proc", strconv.Itoa(pid), "cgroup")
 	data, err := ioutil.ReadFile(cgroupPath)
-	res := map[string]string {}
+	res := map[string]string{}
 	if err != nil {
 		return res, err
 	}
@@ -609,7 +302,7 @@ func parseProcCgroupFile(pid int) (map[string]string, error) {
 	scanner.Split(bufio.ScanLines)
 	getCgWrapperInString := func(source string) (group string, found bool) {
 		for cgroup, _ := range wrapper.Cgroups2Stats {
-			if strings.Index(source, cgroup) >=0 {
+			if strings.Index(source, cgroup) >= 0 {
 				return cgroup, true
 			}
 		}

--- a/common/parse.go
+++ b/common/parse.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+import "strconv"
+
+func ReadUintFromFile(path string, bits int) (uint64, error) {
+	if valb, err := ioutil.ReadFile(path); err != nil {
+		return 0, err
+	} else {
+		var val uint64
+		val, err = strconv.ParseUint(strings.TrimSpace(string(valb)), 10, bits)
+		return val, err
+	}
+}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1,0 +1,634 @@
+// Provides Filesystem Stats
+package fs
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker/pkg/mount"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/wrapper"
+	zfs "github.com/mistifyio/go-zfs"
+)
+
+const (
+	LabelSystemRoot   = "root"
+	LabelDockerImages = "docker-images"
+	LabelRktImages    = "rkt-images"
+)
+const (
+	devicemapperStorageDriver = "devicemapper"
+	aufsStorageDriver         = "aufs"
+	overlayStorageDriver      = "overlay"
+	zfsStorageDriver          = "zfs"
+
+	// The read write layers exist here.
+	aufsRWLayer = "diff"
+	// Path to the directory where docker stores log files if the json logging driver is enabled.
+	pathToContainersDir = "containers"
+
+	storageDir = "/var/lib/docker"
+)
+
+type partition struct {
+	mountpoint string
+	major      uint
+	minor      uint
+	fsType     string
+	blockSize  uint
+}
+
+type RealFsInfo struct {
+	// Map from block device path to partition information.
+	partitions map[string]partition
+	// Map from label to block device path.
+	// Labels are intent-specific tags that are auto-detected.
+	labels map[string]string
+
+	dmsetup dmsetupClient
+}
+
+type Context struct {
+	// docker root directory.
+	Docker  DockerContext
+	RktPath string
+}
+
+type DockerContext struct {
+	Root         string
+	Driver       string
+	DriverStatus map[string]string
+}
+
+func GetFsStats(container *docker.Container) (*wrapper.FilesystemInterface, error) {
+	var (
+		baseUsage           uint64
+		extraUsage          uint64
+		fsStats             *wrapper.FilesystemInterface
+		rootFsStorageDir    = storageDir
+		logsFilesStorageDir string
+	)
+
+	if container.ID != "" {
+		switch container.Driver {
+		case aufsStorageDriver:
+			// `/var/lib/docker/aufs/diff/<docker_id>`
+			rootFsStorageDir = filepath.Join(storageDir, string(aufsStorageDriver), aufsRWLayer, container.ID)
+		case overlayStorageDriver:
+			rootFsStorageDir = filepath.Join(storageDir, string(overlayStorageDriver), container.ID)
+		default:
+			return nil, fmt.Errorf("Filesystem stats for storage driver %+s have not been supported yet", container.Driver)
+		}
+
+		// Path to the directory where docker stores log files, metadata and configs
+		// e.g. /var/lib/docker/container/<docker_id>
+		logsFilesStorageDir = filepath.Join(storageDir, pathToContainersDir, container.ID)
+	}
+
+	fsInfo, err := NewFsInfo(container.Driver)
+	if err != nil {
+		return nil, err
+	}
+
+	deviceInfo, err := fsInfo.GetDirFsDevice(rootFsStorageDir)
+	if err != nil {
+		return nil, err
+	}
+
+	filesystems, err := fsInfo.GetGlobalFsInfo()
+	if err != nil {
+		return nil, fmt.Errorf("Cannot get global filesystem info, err=", err)
+	}
+
+	for _, fs := range filesystems {
+		if fs.Device == deviceInfo.Device {
+
+			fsStats = &wrapper.FilesystemInterface{
+				Device:          fs.Device,
+				Type:            fs.Type.String(),
+				Limit:           fs.Capacity,
+				Usage:           fs.Capacity - fs.Free,
+				InodesFree:      fs.InodesFree,
+				ReadsCompleted:  fs.DiskStats.ReadsCompleted,
+				ReadsMerged:     fs.DiskStats.ReadsMerged,
+				SectorsRead:     fs.DiskStats.SectorsRead,
+				ReadTime:        fs.DiskStats.ReadTime,
+				WritesCompleted: fs.DiskStats.WritesCompleted,
+				WritesMerged:    fs.DiskStats.WritesMerged,
+				SectorsWritten:  fs.DiskStats.SectorsWritten,
+				WriteTime:       fs.DiskStats.WriteTime,
+				IoInProgress:    fs.DiskStats.IoInProgress,
+				IoTime:          fs.DiskStats.IoTime,
+				WeightedIoTime:  fs.DiskStats.WeightedIoTime,
+			}
+
+			break
+		}
+	}
+
+	if rootFsStorageDir != "" {
+		baseUsage, err = fsInfo.GetDirUsage(rootFsStorageDir, time.Second)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot get usage for dir=`%s`, err=%s", rootFsStorageDir, err)
+		}
+	}
+
+	if logsFilesStorageDir != "" {
+		extraUsage, err = fsInfo.GetDirUsage(logsFilesStorageDir, time.Second)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot get usage for dir=`%s`, err=%s", logsFilesStorageDir, err)
+		}
+	}
+
+	fsStats.BaseUsage = baseUsage
+	//filesystem total usage equals baseUsage+extraUsage(logs, configs, etc.)
+	fsStats.Usage = baseUsage + extraUsage
+
+	return fsStats, nil
+}
+
+func NewFsInfo(storageDriver string) (FsInfo, error) {
+	mounts, err := mount.GetMounts()
+	if err != nil {
+		return nil, err
+	}
+	fsInfo := &RealFsInfo{
+		partitions: make(map[string]partition, 0),
+		labels:     make(map[string]string, 0),
+		dmsetup:    &defaultDmsetupClient{},
+	}
+
+	fsInfo.addSystemRootLabel(mounts)
+
+	//fsInfo.addDockerImagesLabel(context, mounts)
+
+	//fsInfo.addRktImagesLabel(context, mounts)
+
+	supportedFsType := map[string]bool{
+		// all ext systems are checked through prefix.
+		"btrfs": true,
+		"xfs":   true,
+		"zfs":   true,
+	}
+	for _, mount := range mounts {
+		var Fstype string
+		if !strings.HasPrefix(mount.Fstype, "ext") && !supportedFsType[mount.Fstype] {
+			continue
+		}
+		// Avoid bind mounts.
+		if _, ok := fsInfo.partitions[mount.Source]; ok {
+			continue
+		}
+		if mount.Fstype == "zfs" {
+			Fstype = mount.Fstype
+		}
+		fsInfo.partitions[mount.Source] = partition{
+			fsType:     Fstype,
+			mountpoint: mount.Mountpoint,
+			major:      uint(mount.Major),
+			minor:      uint(mount.Minor),
+		}
+	}
+
+	return fsInfo, nil
+}
+
+// getDockerDeviceMapperInfo returns information about the devicemapper device and "partition" if
+// docker is using devicemapper for its storage driver. If a loopback device is being used, don't
+// return any information or error, as we want to report based on the actual partition where the
+// loopback file resides, inside of the loopback file itself.
+func (self *RealFsInfo) getDockerDeviceMapperInfo(context DockerContext) (string, *partition, error) {
+	if context.Driver != DeviceMapper.String() {
+		return "", nil, nil
+	}
+
+	dataLoopFile := context.DriverStatus["Data loop file"]
+	if len(dataLoopFile) > 0 {
+		return "", nil, nil
+	}
+
+	dev, major, minor, blockSize, err := dockerDMDevice(context.DriverStatus, self.dmsetup)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return dev, &partition{
+		fsType:    DeviceMapper.String(),
+		major:     major,
+		minor:     minor,
+		blockSize: blockSize,
+	}, nil
+}
+
+// addSystemRootLabel attempts to determine which device contains the mount for /.
+func (self *RealFsInfo) addSystemRootLabel(mounts []*mount.Info) {
+	for _, m := range mounts {
+		if m.Mountpoint == "/" {
+			self.partitions[m.Source] = partition{
+				fsType:     m.Fstype,
+				mountpoint: m.Mountpoint,
+				major:      uint(m.Major),
+				minor:      uint(m.Minor),
+			}
+			self.labels[LabelSystemRoot] = m.Source
+			return
+		}
+	}
+}
+
+/*
+// addDockerImagesLabel attempts to determine which device contains the mount for docker images.
+func (self *RealFsInfo) addDockerImagesLabel(context Context, mounts []*mount.Info) {
+	dockerDev, dockerPartition, err := self.getDockerDeviceMapperInfo(context.Docker)
+	if err != nil {
+		glog.Warningf("Could not get Docker devicemapper device: %v", err)
+	}
+	if len(dockerDev) > 0 && dockerPartition != nil {
+		self.partitions[dockerDev] = *dockerPartition
+		self.labels[LabelDockerImages] = dockerDev
+	} else {
+		self.updateContainerImagesPath(LabelDockerImages, mounts, getDockerImagePaths(context))
+	}
+}
+
+func (self *RealFsInfo) addRktImagesLabel(context Context, mounts []*mount.Info) {
+	if context.RktPath != "" {
+		rktPath := context.RktPath
+		rktImagesPaths := map[string]struct{}{
+			"/": {},
+		}
+		for rktPath != "/" && rktPath != "." {
+			rktImagesPaths[rktPath] = struct{}{}
+			rktPath = filepath.Dir(rktPath)
+		}
+		self.updateContainerImagesPath(LabelRktImages, mounts, rktImagesPaths)
+	}
+}
+*/
+
+// Generate a list of possible mount points for docker image management from the docker root directory.
+// Right now, we look for each type of supported graph driver directories, but we can do better by parsing
+// some of the context from `docker info`.
+func getDockerImagePaths(context Context) map[string]struct{} {
+	dockerImagePaths := map[string]struct{}{
+		"/": {},
+	}
+
+	// TODO(rjnagal): Detect docker root and graphdriver directories from docker info.
+	dockerRoot := context.Docker.Root
+	for _, dir := range []string{"devicemapper", "btrfs", "aufs", "overlay", "zfs"} {
+		dockerImagePaths[path.Join(dockerRoot, dir)] = struct{}{}
+	}
+	for dockerRoot != "/" && dockerRoot != "." {
+		dockerImagePaths[dockerRoot] = struct{}{}
+		dockerRoot = filepath.Dir(dockerRoot)
+	}
+	return dockerImagePaths
+}
+
+// This method compares the mountpoints with possible container image mount points. If a match is found,
+// the label is added to the partition.
+func (self *RealFsInfo) updateContainerImagesPath(label string, mounts []*mount.Info, containerImagePaths map[string]struct{}) {
+	var useMount *mount.Info
+	for _, m := range mounts {
+		if _, ok := containerImagePaths[m.Mountpoint]; ok {
+			if useMount == nil || (len(useMount.Mountpoint) < len(m.Mountpoint)) {
+				useMount = m
+			}
+		}
+	}
+	if useMount != nil {
+		self.partitions[useMount.Source] = partition{
+			fsType:     useMount.Fstype,
+			mountpoint: useMount.Mountpoint,
+			major:      uint(useMount.Major),
+			minor:      uint(useMount.Minor),
+		}
+		self.labels[label] = useMount.Source
+	}
+}
+
+func (self *RealFsInfo) GetDeviceForLabel(label string) (string, error) {
+	dev, ok := self.labels[label]
+	if !ok {
+		return "", fmt.Errorf("non-existent label %q", label)
+	}
+	return dev, nil
+}
+
+func (self *RealFsInfo) GetLabelsForDevice(device string) ([]string, error) {
+	labels := []string{}
+	for label, dev := range self.labels {
+		if dev == device {
+			labels = append(labels, label)
+		}
+	}
+	return labels, nil
+}
+
+func (self *RealFsInfo) GetMountpointForDevice(dev string) (string, error) {
+	p, ok := self.partitions[dev]
+	if !ok {
+		return "", fmt.Errorf("no partition info for device %q", dev)
+	}
+	return p.mountpoint, nil
+}
+
+func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error) {
+	filesystems := make([]Fs, 0)
+	deviceSet := make(map[string]struct{})
+	diskStatsMap, err := getDiskStatsMap("/proc/diskstats")
+	if err != nil {
+		return nil, err
+	}
+	for device, partition := range self.partitions {
+		_, hasMount := mountSet[partition.mountpoint]
+		_, hasDevice := deviceSet[device]
+		if mountSet == nil || (hasMount && !hasDevice) {
+			var (
+				err error
+				fs  Fs
+			)
+			switch partition.fsType {
+			case DeviceMapper.String():
+				fs.Capacity, fs.Free, fs.Available, err = getDMStats(device, partition.blockSize)
+				fs.Type = DeviceMapper
+			case ZFS.String():
+				fs.Capacity, fs.Free, fs.Available, err = getZfstats(device)
+				fs.Type = ZFS
+			default:
+				fs.Capacity, fs.Free, fs.Available, fs.Inodes, fs.InodesFree, err = getVfsStats(partition.mountpoint)
+				fs.Type = VFS
+			}
+			if err != nil {
+				glog.Errorf("Stat fs failed. Error: %v", err)
+			} else {
+				deviceSet[device] = struct{}{}
+				fs.DeviceInfo = DeviceInfo{
+					Device: device,
+					Major:  uint(partition.major),
+					Minor:  uint(partition.minor),
+				}
+				fs.DiskStats = diskStatsMap[device]
+				filesystems = append(filesystems, fs)
+			}
+		}
+	}
+	return filesystems, nil
+}
+
+var partitionRegex = regexp.MustCompile(`^(?:(?:s|xv)d[a-z]+\d*|dm-\d+)$`)
+
+func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
+	diskStatsMap := make(map[string]DiskStats)
+	file, err := os.Open(diskStatsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			glog.Infof("not collecting filesystem statistics because file %q was not available", diskStatsFile)
+			return diskStatsMap, nil
+		}
+		return nil, err
+	}
+
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		words := strings.Fields(line)
+		if !partitionRegex.MatchString(words[2]) {
+			continue
+		}
+		// 8      50 sdd2 40 0 280 223 7 0 22 108 0 330 330
+		deviceName := path.Join("/dev", words[2])
+		wordLength := len(words)
+		offset := 3
+		var stats = make([]uint64, wordLength-offset)
+		if len(stats) < 11 {
+			return nil, fmt.Errorf("could not parse all 11 columns of /proc/diskstats")
+		}
+		var error error
+		for i := offset; i < wordLength; i++ {
+			stats[i-offset], error = strconv.ParseUint(words[i], 10, 64)
+			if error != nil {
+				return nil, error
+			}
+		}
+		diskStats := DiskStats{
+			ReadsCompleted:  stats[0],
+			ReadsMerged:     stats[1],
+			SectorsRead:     stats[2],
+			ReadTime:        stats[3],
+			WritesCompleted: stats[4],
+			WritesMerged:    stats[5],
+			SectorsWritten:  stats[6],
+			WriteTime:       stats[7],
+			IoInProgress:    stats[8],
+			IoTime:          stats[9],
+			WeightedIoTime:  stats[10],
+		}
+		diskStatsMap[deviceName] = diskStats
+	}
+	return diskStatsMap, nil
+}
+
+func (self *RealFsInfo) GetGlobalFsInfo() ([]Fs, error) {
+	return self.GetFsInfoForPath(nil)
+}
+
+func major(devNumber uint64) uint {
+	return uint((devNumber >> 8) & 0xfff)
+}
+
+func minor(devNumber uint64) uint {
+	return uint((devNumber & 0xff) | ((devNumber >> 12) & 0xfff00))
+}
+
+func (self *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
+	buf := new(syscall.Stat_t)
+	err := syscall.Stat(dir, buf)
+	if err != nil {
+		return nil, fmt.Errorf("stat failed on %s with error: %s", dir, err)
+	}
+	major := major(buf.Dev)
+	minor := minor(buf.Dev)
+	for device, partition := range self.partitions {
+		if partition.major == major && partition.minor == minor {
+			return &DeviceInfo{device, major, minor}, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find device with major: %d, minor: %d in cached partitions map", major, minor)
+}
+
+func (self *RealFsInfo) GetDirUsage(dir string, timeout time.Duration) (uint64, error) {
+	if dir == "" {
+		return 0, fmt.Errorf("invalid directory")
+	}
+	cmd := exec.Command("nice", "-n", "19", "du", "-s", dir)
+	stdoutp, err := cmd.StdoutPipe()
+	if err != nil {
+		return 0, fmt.Errorf("failed to setup stdout for cmd %v - %v", cmd.Args, err)
+	}
+	stderrp, err := cmd.StderrPipe()
+	if err != nil {
+		return 0, fmt.Errorf("failed to setup stderr for cmd %v - %v", cmd.Args, err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("failed to exec du - %v", err)
+	}
+	stdoutb, souterr := ioutil.ReadAll(stdoutp)
+	stderrb, _ := ioutil.ReadAll(stderrp)
+	timer := time.AfterFunc(timeout, func() {
+		glog.Infof("killing cmd %v due to timeout(%s)", cmd.Args, timeout.String())
+		cmd.Process.Kill()
+	})
+	err = cmd.Wait()
+	timer.Stop()
+	if err != nil {
+		return 0, fmt.Errorf("du command failed on %s with output stdout: %s, stderr: %s - %v", dir, string(stdoutb), string(stderrb), err)
+	}
+	stdout := string(stdoutb)
+	if souterr != nil {
+		glog.Errorf("failed to read from stdout for cmd %v - %v", cmd.Args, souterr)
+	}
+	usageInKb, err := strconv.ParseUint(strings.Fields(stdout)[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse 'du' output %s - %s", stdout, err)
+	}
+	return usageInKb * 1024, nil
+}
+
+func getVfsStats(path string) (total uint64, free uint64, avail uint64, inodes uint64, inodesFree uint64, err error) {
+	var s syscall.Statfs_t
+	if err = syscall.Statfs(path, &s); err != nil {
+		return 0, 0, 0, 0, 0, err
+	}
+	total = uint64(s.Frsize) * s.Blocks
+	free = uint64(s.Frsize) * s.Bfree
+	avail = uint64(s.Frsize) * s.Bavail
+	inodes = uint64(s.Files)
+	inodesFree = uint64(s.Ffree)
+	return total, free, avail, inodes, inodesFree, nil
+}
+
+// dmsetupClient knows to to interact with dmsetup to retrieve information about devicemapper.
+type dmsetupClient interface {
+	table(poolName string) ([]byte, error)
+	//TODO add status(poolName string) ([]byte, error) and use it in getDMStats so we can unit test
+}
+
+// defaultDmsetupClient implements the standard behavior for interacting with dmsetup.
+type defaultDmsetupClient struct{}
+
+var _ dmsetupClient = &defaultDmsetupClient{}
+
+func (*defaultDmsetupClient) table(poolName string) ([]byte, error) {
+	return exec.Command("dmsetup", "table", poolName).Output()
+}
+
+// Devicemapper thin provisioning is detailed at
+// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
+func dockerDMDevice(driverStatus map[string]string, dmsetup dmsetupClient) (string, uint, uint, uint, error) {
+	poolName, ok := driverStatus["Pool Name"]
+	if !ok || len(poolName) == 0 {
+		return "", 0, 0, 0, fmt.Errorf("Could not get dm pool name")
+	}
+
+	out, err := dmsetup.table(poolName)
+	if err != nil {
+		return "", 0, 0, 0, err
+	}
+
+	major, minor, dataBlkSize, err := parseDMTable(string(out))
+	if err != nil {
+		return "", 0, 0, 0, err
+	}
+
+	return poolName, major, minor, dataBlkSize, nil
+}
+
+func parseDMTable(dmTable string) (uint, uint, uint, error) {
+	dmTable = strings.Replace(dmTable, ":", " ", -1)
+	dmFields := strings.Fields(dmTable)
+
+	if len(dmFields) < 8 {
+		return 0, 0, 0, fmt.Errorf("Invalid dmsetup status output: %s", dmTable)
+	}
+
+	major, err := strconv.ParseUint(dmFields[5], 10, 32)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	minor, err := strconv.ParseUint(dmFields[6], 10, 32)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	dataBlkSize, err := strconv.ParseUint(dmFields[7], 10, 32)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return uint(major), uint(minor), uint(dataBlkSize), nil
+}
+
+func getDMStats(poolName string, dataBlkSize uint) (uint64, uint64, uint64, error) {
+	out, err := exec.Command("dmsetup", "status", poolName).Output()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	used, total, err := parseDMStatus(string(out))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	used *= 512 * uint64(dataBlkSize)
+	total *= 512 * uint64(dataBlkSize)
+	free := total - used
+
+	return total, free, free, nil
+}
+
+func parseDMStatus(dmStatus string) (uint64, uint64, error) {
+	dmStatus = strings.Replace(dmStatus, "/", " ", -1)
+	dmFields := strings.Fields(dmStatus)
+
+	if len(dmFields) < 8 {
+		return 0, 0, fmt.Errorf("Invalid dmsetup status output: %s", dmStatus)
+	}
+
+	used, err := strconv.ParseUint(dmFields[6], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	total, err := strconv.ParseUint(dmFields[7], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return used, total, nil
+}
+
+// getZfstats returns ZFS mount stats using zfsutils
+func getZfstats(poolName string) (uint64, uint64, uint64, error) {
+	dataset, err := zfs.GetDataset(poolName)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	total := dataset.Used + dataset.Avail + dataset.Usedbydataset
+
+	return total, dataset.Avail, dataset.Avail, nil
+}

--- a/fs/types.go
+++ b/fs/types.go
@@ -1,0 +1,69 @@
+package fs
+
+import "time"
+
+type DeviceInfo struct {
+	Device string
+	Major  uint
+	Minor  uint
+}
+
+type FsType string
+
+func (ft FsType) String() string {
+	return string(ft)
+}
+
+const (
+	ZFS          FsType = "zfs"
+	DeviceMapper FsType = "devicemapper"
+	VFS          FsType = "vfs"
+)
+
+type Fs struct {
+	DeviceInfo
+	Type       FsType
+	Capacity   uint64
+	Free       uint64
+	Available  uint64
+	Inodes     uint64
+	InodesFree uint64
+	DiskStats  DiskStats
+}
+
+type DiskStats struct {
+	ReadsCompleted  uint64
+	ReadsMerged     uint64
+	SectorsRead     uint64
+	ReadTime        uint64
+	WritesCompleted uint64
+	WritesMerged    uint64
+	SectorsWritten  uint64
+	WriteTime       uint64
+	IoInProgress    uint64
+	IoTime          uint64
+	WeightedIoTime  uint64
+}
+
+type FsInfo interface {
+	// Returns capacity and free space, in bytes, of all the ext2, ext3, ext4 filesystems on the host.
+	GetGlobalFsInfo() ([]Fs, error)
+
+	// Returns capacity and free space, in bytes, of the set of mounts passed.
+	GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error)
+
+	// Returns number of bytes occupied by 'dir'.
+	GetDirUsage(dir string, timeout time.Duration) (uint64, error)
+
+	// Returns the block device info of the filesystem on which 'dir' resides.
+	GetDirFsDevice(dir string) (*DeviceInfo, error)
+
+	// Returns the device name associated with a particular label.
+	GetDeviceForLabel(label string) (string, error)
+
+	// Returns all labels associated with a particular device name.
+	GetLabelsForDevice(device string) ([]string, error)
+
+	// Returns the mountpoint associated with a particular device.
+	GetMountpointForDevice(device string) (string, error)
+}

--- a/network/network.go
+++ b/network/network.go
@@ -1,0 +1,197 @@
+// Provides Network Stats
+package network
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/common"
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/wrapper"
+	"github.com/intelsdi-x/snap-plugin-utilities/ns"
+)
+
+const networkInterfacesDir = "/sys/class/net"
+
+var networkMetrics = getListOfNetworkMetrics()
+
+func getListOfNetworkMetrics() []string {
+	metrics := []string{}
+	ns.FromCompositionTags(wrapper.NetworkInterface{}, "", &metrics)
+	return metrics
+}
+
+func NetworkStatsFromProc(rootFs string, pid int) (ifaceStats []wrapper.NetworkInterface, errout error) {
+
+	netStatsFile := filepath.Join(rootFs, "proc", strconv.Itoa(pid), "/net/dev")
+	var err error
+	ifaceStats, err = scanInterfaceStats(netStatsFile)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read network stats: %v", err)
+	}
+
+	if len(ifaceStats) == 0 {
+		return nil, errors.New("No network interface found")
+	}
+
+	return ifaceStats, nil
+}
+
+func NetworkStatsFromRoot() (ifaceStats []wrapper.NetworkInterface, _ error) {
+	devNames, err := listRootNetworkDevices()
+	if err != nil {
+		return nil, err
+	}
+	ifaceStats = []wrapper.NetworkInterface{}
+	for _, name := range devNames {
+		if isIgnoredDevice(name) {
+			continue
+		}
+		if stats, err := interfaceStatsFromDir(name); err != nil {
+			return nil, err
+		} else {
+			ifaceStats = append(ifaceStats, *stats)
+		}
+	}
+	return ifaceStats, nil
+}
+
+func listRootNetworkDevices() (devNames []string, _ error) {
+	entries, err := ioutil.ReadDir(networkInterfacesDir)
+	if err != nil {
+		return nil, err
+	}
+	devNames = []string{}
+	for _, e := range entries {
+		if e.Mode()&os.ModeSymlink == os.ModeSymlink {
+			e, err = os.Stat(filepath.Join(networkInterfacesDir, e.Name()))
+			if err != nil || !e.IsDir() {
+				continue
+			}
+			devNames = append(devNames, e.Name())
+		} else if e.IsDir() {
+			devNames = append(devNames, e.Name())
+		}
+	}
+	return devNames, nil
+}
+
+func interfaceStatsFromDir(ifaceName string) (*wrapper.NetworkInterface, error) {
+	stats := wrapper.NetworkInterface{Name: ifaceName}
+	statsValues := map[string]uint64{}
+	for _, metric := range networkMetrics {
+		if metric == "name" {
+			continue
+		}
+		val, err := common.ReadUintFromFile(filepath.Join(networkInterfacesDir, ifaceName, "statistics", metric), 64)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't read interface statistics %s/%s: %v", ifaceName, metric, err)
+		}
+		statsValues[metric] = val
+	}
+	SetIfaceStatsFromMap(&stats, statsValues)
+	return &stats, nil
+}
+
+func SetIfaceStatsFromMap(stats *wrapper.NetworkInterface, values map[string]uint64) {
+	stats.RxBytes = values["rx_bytes"]
+	stats.RxErrors = values["rx_errors"]
+	stats.RxPackets = values["rx_packets"]
+	stats.RxDropped = values["rx_dropped"]
+	stats.TxBytes = values["tx_bytes"]
+	stats.TxErrors = values["tx_errors"]
+	stats.TxPackets = values["tx_packets"]
+	stats.TxDropped = values["tx_dropped"]
+}
+
+func SetMapFromIfaceStats(values map[string]uint64, stats *wrapper.NetworkInterface) {
+	values["rx_bytes"] = stats.RxBytes
+	values["rx_errors"] = stats.RxErrors
+	values["rx_packets"] = stats.RxPackets
+	values["rx_dropped"] = stats.RxDropped
+	values["tx_bytes"] = stats.TxBytes
+	values["tx_errors"] = stats.TxErrors
+	values["tx_packets"] = stats.TxPackets
+	values["tx_dropped"] = stats.TxDropped
+}
+
+func isIgnoredDevice(ifName string) bool {
+	ignoredDevicePrefixes := []string{"lo", "veth", "docker"}
+	for _, prefix := range ignoredDevicePrefixes {
+		if strings.HasPrefix(strings.ToLower(ifName), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func scanInterfaceStats(netStatsFile string) ([]wrapper.NetworkInterface, error) {
+	file, err := os.Open(netStatsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failure opening %s: %v", netStatsFile, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	// Discard header lines
+	for i := 0; i < 2; i++ {
+		if b := scanner.Scan(); !b {
+			return nil, scanner.Err()
+		}
+	}
+
+	stats := []wrapper.NetworkInterface{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.Replace(line, ":", "", -1)
+
+		fields := strings.Fields(line)
+		// If the format of the  line is invalid then don't trust any of the stats
+		// in this file.
+		if len(fields) != 17 {
+			return nil, fmt.Errorf("invalid interface stats line: %v", line)
+		}
+
+		devName := fields[0]
+
+		if isIgnoredDevice(devName) {
+			continue
+		}
+
+		i := wrapper.NetworkInterface{
+			Name: devName,
+		}
+
+		statFields := append(fields[1:5], fields[9:13]...)
+		statPointers := []*uint64{
+			&i.RxBytes, &i.RxPackets, &i.RxErrors, &i.RxDropped,
+			&i.TxBytes, &i.TxPackets, &i.TxErrors, &i.TxDropped,
+		}
+
+		err := setInterfaceStatValues(statFields, statPointers)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse interface stats (%v): %v", err, line)
+		}
+
+		stats = append(stats, i)
+	}
+
+	return stats, nil
+}
+
+func setInterfaceStatValues(fields []string, pointers []*uint64) error {
+	for i, v := range fields {
+		val, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return err
+		}
+		*pointers[i] = val
+	}
+	return nil
+}

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -1,0 +1,96 @@
+// Provides Network Stats (TCP and TCP6)
+package network
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/wrapper"
+)
+
+func TcpStatsFromProc(rootFs string, pid int) (wrapper.TcpStat, error) {
+	return tcpStatsFromProc(rootFs, pid, "net/tcp")
+}
+
+func Tcp6StatsFromProc(rootFs string, pid int) (wrapper.TcpStat, error) {
+	return tcpStatsFromProc(rootFs, pid, "net/tcp6")
+}
+
+func tcpStatsFromProc(rootFs string, pid int, file string) (wrapper.TcpStat, error) {
+	tcpStatsFile := filepath.Join(rootFs, "proc", strconv.Itoa(pid), file)
+
+	tcpStats, err := scanTcpStats(tcpStatsFile)
+	if err != nil {
+		return tcpStats, fmt.Errorf("Cannot obtain tcp stats: %v", err)
+	}
+
+	return tcpStats, nil
+}
+
+func scanTcpStats(tcpStatsFile string) (wrapper.TcpStat, error) {
+
+	var stats wrapper.TcpStat
+
+	data, err := ioutil.ReadFile(tcpStatsFile)
+	if err != nil {
+		return stats, fmt.Errorf("Cannot open %s: %v", tcpStatsFile, err)
+	}
+
+	tcpStateMap := map[string]uint64{
+		"01": 0, //ESTABLISHED
+		"02": 0, //SYN_SENT
+		"03": 0, //SYN_RECV
+		"04": 0, //FIN_WAIT1
+		"05": 0, //FIN_WAIT2
+		"06": 0, //TIME_WAIT
+		"07": 0, //CLOSE
+		"08": 0, //CLOSE_WAIT
+		"09": 0, //LAST_ACK
+		"0A": 0, //LISTEN
+		"0B": 0, //CLOSING
+	}
+
+	reader := strings.NewReader(string(data))
+	scanner := bufio.NewScanner(reader)
+
+	scanner.Split(bufio.ScanLines)
+
+	// Discard header line
+	if b := scanner.Scan(); !b {
+		return stats, scanner.Err()
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		state := strings.Fields(line)
+		// TCP state is the 4th field.
+		// Format: sl local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt  uid timeout inode
+		tcpState := state[3]
+		_, ok := tcpStateMap[tcpState]
+		if !ok {
+			return stats, fmt.Errorf("invalid TCP stats line: %v", line)
+		}
+		tcpStateMap[tcpState]++
+	}
+
+	stats = wrapper.TcpStat{
+		Established: tcpStateMap["01"],
+		SynSent:     tcpStateMap["02"],
+		SynRecv:     tcpStateMap["03"],
+		FinWait1:    tcpStateMap["04"],
+		FinWait2:    tcpStateMap["05"],
+		TimeWait:    tcpStateMap["06"],
+		Close:       tcpStateMap["07"],
+		CloseWait:   tcpStateMap["08"],
+		LastAck:     tcpStateMap["09"],
+		Listen:      tcpStateMap["0A"],
+		Closing:     tcpStateMap["0B"],
+	}
+
+	return stats, nil
+}

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,10 +49,11 @@ type Stats interface {
 }
 
 type Statistics struct {
-	Network     []NetworkInterface `json:"network"`
-	Connection  TcpInterface       `json:"connection"` //TCP, TCP6 connection stats
-	CgroupStats *cgroups.Stats     `json:"cgroups"`
-	Labels      map[string]string  `json:"labels"`
+	Network     []NetworkInterface   `json:"network"`
+	Connection  TcpInterface         `json:"connection"` //TCP, TCP6 connection stats
+	CgroupStats *cgroups.Stats       `json:"cgroups"`
+	Labels      map[string]string    `json:"labels"`
+	Filesystem  *FilesystemInterface `json:"filesystem"`
 }
 
 type NetworkInterface struct {
@@ -69,6 +70,67 @@ type NetworkInterface struct {
 	TxDropped uint64 `json:"tx_dropped"`
 }
 
+type FilesystemInterface struct {
+	// The block device name associated with the filesystem.
+	Device string `json:"device_name"`
+
+	// Type of the filesystem.
+	Type string `json:"type"`
+
+	// Number of bytes that can be consumed by the container on this filesystem.
+	Limit uint64 `json:"capacity"`
+
+	// Number of bytes that is consumed by the container on this filesystem.
+	Usage uint64 `json:"usage"`
+
+	// Base Usage that is consumed by the container's writable layer.
+	BaseUsage uint64 `json:"base_usage"`
+
+	// Number of bytes available for non-root user.
+	Available uint64 `json:"available"`
+
+	// Number of available Inodes
+	InodesFree uint64 `json:"inodes_free"`
+
+	// This is the total number of reads completed successfully.
+	ReadsCompleted uint64 `json:"reads_completed"`
+
+	// This is the total number of reads merged successfully. This field lets you know how often this was done.
+	ReadsMerged uint64 `json:"reads_merged"`
+
+	// This is the total number of sectors read successfully.
+	SectorsRead uint64 `json:"sectors_read"`
+
+	// This is the total number of milliseconds spent reading
+	ReadTime uint64 `json:"read_time"`
+
+	// This is the total number of writes completed successfully.
+	WritesCompleted uint64 `json:"writes_completed"`
+
+	// This is the total number of writes merged successfully. This field lets you know how often this was done.
+	WritesMerged uint64 `json:"writes_merged"`
+
+	// This is the total number of sectors written successfully.
+	SectorsWritten uint64 `json:"sectors_written"`
+
+	// This is the total number of milliseconds spent writing
+	WriteTime uint64 `json:"write_time"`
+
+	// Number of I/Os currently in progress
+	IoInProgress uint64 `json:"io_in_progress"`
+
+	// Number of milliseconds spent doing I/Os
+	IoTime uint64 `json:"io_time"`
+
+	// weighted number of milliseconds spent doing I/Os
+	// This field is incremented at each I/O start, I/O completion, I/O
+	// merge, or read of these stats by the number of I/Os in progress
+	// (field 9) times the number of milliseconds spent doing I/O since the
+	// last update of this field.  This can provide an easy measure of both
+	// I/O completion time and the backlog that may be accumulating.
+	WeightedIoTime uint64 `json:"weighted_io_time"`
+}
+
 func NewStatistics() *Statistics {
 	return &Statistics{
 		Network:     []NetworkInterface{},
@@ -77,7 +139,8 @@ func NewStatistics() *Statistics {
 			Tcp:  TcpStat{},
 			Tcp6: TcpStat{},
 		},
-		Labels: map[string]string {},
+		Labels:     map[string]string{},
+		Filesystem: &FilesystemInterface{},
 	}
 }
 


### PR DESCRIPTION
Added:

```
/intel/docker/*/filesystem/available                                     8
/intel/docker/*/filesystem/base_usage                                    8
/intel/docker/*/filesystem/capacity                                      8
/intel/docker/*/filesystem/device_name                                   8
/intel/docker/*/filesystem/inodes_free                                   8
/intel/docker/*/filesystem/io_in_progress                                8
/intel/docker/*/filesystem/io_time                                       8
/intel/docker/*/filesystem/read_time                                     8
/intel/docker/*/filesystem/reads_completed                               8
/intel/docker/*/filesystem/reads_merged                                  8
/intel/docker/*/filesystem/sectors_read                                  8
/intel/docker/*/filesystem/sectors_written                               8
/intel/docker/*/filesystem/type                                          8
/intel/docker/*/filesystem/usage                                         8
/intel/docker/*/filesystem/weighted_io_time                              8
/intel/docker/*/filesystem/write_time                                    8
/intel/docker/*/filesystem/writes_completed                              8
/intel/docker/*/filesystem/writes_merged                                 8
```

Plus moved retrieving network and tcp stats to separate package `network`
