### PR TITLE
Limit amount of cgroup metrics  - removed blkio and hugetlb stats

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -35,9 +35,9 @@ import (
 	"time"
 
 	dock "github.com/fsouza/go-dockerclient"
+	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/util"
 	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/wrapper"
 	"runtime/debug"
-	"github.com/intelsdi-x/kubesnap-plugin-collector-docker/util"
 )
 
 const (
@@ -426,7 +426,6 @@ func (d *docker) GetMetricTypes(_ plugin.ConfigType) ([]plugin.MetricType, error
 	// copy memory section from root container to have valid indexes in stats
 	stats.CgroupStats.MemoryStats = rootStats.CgroupStats.MemoryStats
 	stats.CgroupStats.CpuStats = rootStats.CgroupStats.CpuStats
-	fmt.Fprintln(os.Stderr, "Debug, iza filesystem struct=", stats.Filesystem)
 
 	// set new item to docker.container structure
 	data := containerData{
@@ -444,8 +443,7 @@ func (d *docker) GetMetricTypes(_ plugin.ConfigType) ([]plugin.MetricType, error
 	// take names of available metrics based on tags for containerData type; do not add prefix (empty string)
 	ns.FromCompositionTags(data, "spec", &specificationMetrics)
 	//ns.FromCompositionTags(data.Stats.CgroupStats, "cgroups", &cgroupsMetrics)
-	ns.FromCompositeObject(data.Stats.CgroupStats, "cgroups", &cgroupsMetrics,
-		ns.InspectNilPointers(ns.AlwaysFalse))
+	ns.FromCompositionTags(data.Stats.CgroupStats, "cgroups", &cgroupsMetrics)
 	ns.FromCompositionTags(wrapper.NetworkInterface{}, "", &networkMetrics)
 	ns.FromCompositionTags(data.Stats.Connection, "connection", &connectionMetrics)
 	ns.FromCompositionTags(data.Stats.Filesystem, "filesystem", &filesystemMetrics)

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -27,17 +27,17 @@ import (
 )
 
 var Cgroups2Stats = map[string]Stats{
-	"cpuset":     &fs.CpusetGroup{},
-	"cpu":        &fs.CpuGroup{},
-	"cpuacct":    &fs.CpuacctGroup{},
-	"memory":     &fs.MemoryGroup{},
-	"devices":    &fs.DevicesGroup{},
-	"freezer":    &fs.FreezerGroup{},
-	"net_cls":    &fs.NetClsGroup{},
-	"blkio":      &fs.BlkioGroup{},
+	"cpuset":  &fs.CpusetGroup{},
+	"cpu":     &fs.CpuGroup{},
+	"cpuacct": &fs.CpuacctGroup{},
+	"memory":  &fs.MemoryGroup{},
+	"devices": &fs.DevicesGroup{},
+	"freezer": &fs.FreezerGroup{},
+	"net_cls": &fs.NetClsGroup{},
+	//"blkio":      &fs.BlkioGroup{},
 	"perf_event": &fs.PerfEventGroup{},
 	"net_prio":   &fs.NetPrioGroup{},
-	"hugetlb":    &fs.HugetlbGroup{},
+	//"hugetlb":    &fs.HugetlbGroup{},
 }
 
 type Stats interface {


### PR DESCRIPTION
The following metrics are no longer exposed:

```
NAMESPACE                                                                VERSIONS
/intel/docker/*/cgroups/blkio_stats/io_merged_recursive/*/major          9
/intel/docker/*/cgroups/blkio_stats/io_merged_recursive/*/minor          9
/intel/docker/*/cgroups/blkio_stats/io_merged_recursive/*/op             9
/intel/docker/*/cgroups/blkio_stats/io_merged_recursive/*/value          9
/intel/docker/*/cgroups/blkio_stats/io_queue_recursive/*/major           9
/intel/docker/*/cgroups/blkio_stats/io_queue_recursive/*/minor           9
/intel/docker/*/cgroups/blkio_stats/io_queue_recursive/*/op              9
/intel/docker/*/cgroups/blkio_stats/io_queue_recursive/*/value           9
/intel/docker/*/cgroups/blkio_stats/io_service_bytes_recursive/*/major   9
/intel/docker/*/cgroups/blkio_stats/io_service_bytes_recursive/*/minor   9
/intel/docker/*/cgroups/blkio_stats/io_service_bytes_recursive/*/op      9
/intel/docker/*/cgroups/blkio_stats/io_service_bytes_recursive/*/value   9
/intel/docker/*/cgroups/blkio_stats/io_service_time_recursive/*/major    9
/intel/docker/*/cgroups/blkio_stats/io_service_time_recursive/*/minor    9
/intel/docker/*/cgroups/blkio_stats/io_service_time_recursive/*/op       9
/intel/docker/*/cgroups/blkio_stats/io_service_time_recursive/*/value    9
/intel/docker/*/cgroups/blkio_stats/io_serviced_recursive/*/major        9
/intel/docker/*/cgroups/blkio_stats/io_serviced_recursive/*/minor        9
/intel/docker/*/cgroups/blkio_stats/io_serviced_recursive/*/op           9
/intel/docker/*/cgroups/blkio_stats/io_serviced_recursive/*/value        9
/intel/docker/*/cgroups/blkio_stats/io_time_recursive/*/major            9
/intel/docker/*/cgroups/blkio_stats/io_time_recursive/*/minor            9
/intel/docker/*/cgroups/blkio_stats/io_time_recursive/*/op               9
/intel/docker/*/cgroups/blkio_stats/io_time_recursive/*/value            9
/intel/docker/*/cgroups/blkio_stats/io_wait_time_recursive/*/major       9
/intel/docker/*/cgroups/blkio_stats/io_wait_time_recursive/*/minor       9
/intel/docker/*/cgroups/blkio_stats/io_wait_time_recursive/*/op          9
/intel/docker/*/cgroups/blkio_stats/io_wait_time_recursive/*/value       9
/intel/docker/*/cgroups/blkio_stats/sectors_recursive/*/major            9
/intel/docker/*/cgroups/blkio_stats/sectors_recursive/*/minor            9
/intel/docker/*/cgroups/blkio_stats/sectors_recursive/*/op               9
/intel/docker/*/cgroups/blkio_stats/sectors_recursive/*/value            9

/intel/docker/*/cgroups/hugetlb_stats/*/failcnt                          9
/intel/docker/*/cgroups/hugetlb_stats/*/max_usage                        9
/intel/docker/*/cgroups/hugetlb_stats/*/usage                            9

```
