### PR TITLE
Expose filesystem metrics per all available devices

### DIFF
--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -45,11 +45,11 @@ type Stats interface {
 }
 
 type Statistics struct {
-	Network     []NetworkInterface   `json:"network"`
-	Connection  TcpInterface         `json:"connection"` //TCP, TCP6 connection stats
-	CgroupStats *cgroups.Stats       `json:"cgroups"`
-	Labels      map[string]string    `json:"labels"`
-	Filesystem  *FilesystemInterface `json:"filesystem"`
+	Network     []NetworkInterface             `json:"network"`
+	Connection  TcpInterface                   `json:"connection"` //TCP, TCP6 connection stats
+	CgroupStats *cgroups.Stats                 `json:"cgroups"`
+	Labels      map[string]string              `json:"labels"`
+	Filesystem  map[string]FilesystemInterface `json:"filesystem"`
 }
 
 type NetworkInterface struct {
@@ -136,7 +136,7 @@ func NewStatistics() *Statistics {
 			Tcp6: TcpStat{},
 		},
 		Labels:     map[string]string{},
-		Filesystem: &FilesystemInterface{},
+		Filesystem: map[string]FilesystemInterface{},
 	}
 }
 


### PR DESCRIPTION
**Before:**

```
/intel/docker/*/filesystem/available                                   
/intel/docker/*/filesystem/base_usage                                  
/intel/docker/*/filesystem/capacity                                   
/intel/docker/*/filesystem/device_name                                
/intel/docker/*/filesystem/inodes_free                                
/intel/docker/*/filesystem/io_in_progress                              
/intel/docker/*/filesystem/io_time                                     
/intel/docker/*/filesystem/read_time                                   
/intel/docker/*/filesystem/reads_completed                            
/intel/docker/*/filesystem/reads_merged                               
/intel/docker/*/filesystem/sectors_read                               
/intel/docker/*/filesystem/sectors_written                             
/intel/docker/*/filesystem/type                                        
/intel/docker/*/filesystem/usage                                       
/intel/docker/*/filesystem/weighted_io_time                            
/intel/docker/*/filesystem/write_time                                  
/intel/docker/*/filesystem/writes_completed                           
/intel/docker/*/filesystem/writes_merged                               
```

**Now filesystem metrics are per device:**
e.g. `/intel/docker/<docker_id>/filesystem/<device_name>/available`

```
/intel/docker/*/filesystem/*/available                                   
/intel/docker/*/filesystem/*/base_usage                                  
/intel/docker/*/filesystem/*/capacity                                    
/intel/docker/*/filesystem/*/device_name                                 
/intel/docker/*/filesystem/*/inodes_free                                 
/intel/docker/*/filesystem/*/io_in_progress                             
/intel/docker/*/filesystem/*/io_time                                     
/intel/docker/*/filesystem/*/read_time                                  
/intel/docker/*/filesystem/*/reads_completed                             
/intel/docker/*/filesystem/*/reads_merged                               
/intel/docker/*/filesystem/*/sectors_read                                
/intel/docker/*/filesystem/*/sectors_written                             
/intel/docker/*/filesystem/*/type                                        
/intel/docker/*/filesystem/*/usage                                       
/intel/docker/*/filesystem/*/weighted_io_time                            
/intel/docker/*/filesystem/*/write_time                                  
/intel/docker/*/filesystem/*/writes_completed                            
/intel/docker/*/filesystem/*/writes_merged                               
```
