### PR TITLE
Fixed filesystem metrics - do not expose `none` device

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -179,8 +179,6 @@ func GetSubsystemPath(subsystem string, id string) (string, error) {
 		if !isHost(id) {
 			groupPath = filepath.Join(groupPath, "docker-"+id+".scope")
 		}
-
-		//fmt.Fprintf(os.Stderr, "Debug, recognized as systemd, groupPath=", groupPath)
 		return groupPath, nil
 	}
 
@@ -188,9 +186,6 @@ func GetSubsystemPath(subsystem string, id string) (string, error) {
 		groupPath = filepath.Join(groupPath, id)
 
 	}
-
-	//fmt.Fprintf(os.Stderr, "Debug, NOT recognized as systemd, groupPath=", groupPath)
-
 	return groupPath, nil
 }
 
@@ -217,7 +212,6 @@ func (dc *dockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 		container, err = dc.InspectContainer(id)
 
 		if err != nil {
-			//fmt.Fprintf(os.Stderr, "Unable to get inspect container to get pid, err=", err)
 			// only log error message and return stats (contains cgroups stats)
 			return stats, nil
 		}
@@ -228,16 +222,12 @@ func (dc *dockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 		var groupPath string
 		var err error
 
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 1 (subsystem path) - for cg=", cg, " ...")
 		groupPath, err = GetSubsystemPath(cg, id)
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 1 (subsystem path) - for cg=", cg, " ... done, err=", err)
 		if err != nil {
 			continue
 		}
 		// get cgroup stats for given docker
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 2 (get stats) - for cg=", cg, " for groupPath=", groupPath, " ...")
 		err = stat.GetStats(groupPath, stats.CgroupStats)
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 2 (get stats) - for cg=", cg, " for groupPath=", groupPath, " ...done, err=", err)
 		if err != nil {
 			// just log about it
 			if isHost(id) {
@@ -249,7 +239,6 @@ func (dc *dockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 		}
 	}
 
-	//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 3 (calculate memory_working_set) ...")
 	// calculate additional stats memory:working_set based on memory_stats
 	if totalInactiveAnon, ok := stats.CgroupStats.MemoryStats.Stats["total_inactive_anon"]; ok {
 		workingSet = stats.CgroupStats.MemoryStats.Usage.Usage
@@ -267,10 +256,8 @@ func (dc *dockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 			}
 		}
 	}
-	//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 3 (calculate memory_working_set) ... almost done")
 	stats.CgroupStats.MemoryStats.Stats["working_set"] = workingSet
 
-	//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 3 (calculate memory_working_set) ... done")
 	/* todo ask about it
 	// gather memory limit
 	if cgPath, gotMem := wrapperPaths["memory"]; gotMem {
@@ -315,9 +302,7 @@ func (dc *dockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 		}
 
 	} else {
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 4 (get network stats) ...")
 		stats.Network, err = network.NetworkStatsFromRoot()
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 4 (get network stats) ...done, err=", err)
 		if err != nil {
 			// only log error message
 			fmt.Fprintf(os.Stderr, "Unable to get network stats, containerID=%v, %v", id, err)
@@ -325,14 +310,12 @@ func (dc *dockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 
 	}
 	if collectFs {
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 5 (get filesystem stats) ...")
 		stats.Filesystem, err = fs.GetFsStats(container)
-		//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer phase 5 (get filesystem stats) ...done, err=", err)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to get filesystem stats for docker: %v, err=", id, err)
 		}
 	}
-	//fmt.Fprintln(os.Stderr, "Debug, GetStatsContainer, END")
+
 	return stats, nil
 }
 


### PR DESCRIPTION
- expose only these devices for which stats are available
- debug prints removed
